### PR TITLE
feat: add utility functions for FBX transformation and data extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sruim/fbx2gltf",
+  "name": "@sruimeng/fbx2gltf",
   "version": "0.0.1",
   "description": "FBX2glTF is a command-line tool for the conversion of 3D model assets on the FBX file format to the glTF file format.",
   "module": "./dist/index.mjs",
@@ -31,11 +31,11 @@
     "prepare": "husky install",
     "prepublishOnly": "pnpm build"
   },
-  "browserslist": [
-  ],
+  "browserslist": [],
   "dependencies": {
-  },
-  "peerDependencies": {
+    "@gltf-transform/core": "^4.1.3",
+    "fflate": "^0.8.2",
+    "three": "^0.176.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",
@@ -45,6 +45,7 @@
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@swc/core": "^1.4.13",
     "@swc/helpers": "^0.5.8",
+    "@types/three": "^0.176.0",
     "@typescript-eslint/eslint-plugin": "^7.10.0",
     "@typescript-eslint/parser": "^7.10.0",
     "@vitejs/plugin-legacy": "^4.1.1",
@@ -54,7 +55,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "husky": "^7.0.4",
     "lint-staged": "^11.2.6",
-    "pnpm": "^8.15.8",
+    "pnpm": "10.10.0",
     "rimraf": "4",
     "rollup": "^2.79.1",
     "rollup-plugin-swc3": "^0.11.0",
@@ -74,5 +75,6 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"
-  }
+  },
+  "packageManager": "pnpm@10.10.0+sha512.d615db246fe70f25dcfea6d8d73dee782ce23e2245e3c4f6f888249fb568149318637dca73c2c5c8ef2a4ca0d5657fb9567188bfab47f566d1ee6ce987815c39"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,16 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@gltf-transform/core':
+        specifier: ^4.1.3
+        version: 4.1.3
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.2
+      three:
+        specifier: ^0.176.0
+        version: 0.176.0
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.3.0
@@ -29,6 +39,9 @@ importers:
       '@swc/helpers':
         specifier: ^0.5.8
         version: 0.5.11
+      '@types/three':
+        specifier: ^0.176.0
+        version: 0.176.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.10.0
         version: 7.13.0(@typescript-eslint/parser@7.13.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
@@ -57,8 +70,8 @@ importers:
         specifier: ^11.2.6
         version: 11.2.6
       pnpm:
-        specifier: ^8.15.8
-        version: 8.15.8
+        specifier: 10.10.0
+        version: 10.10.0
       rimraf:
         specifier: '4'
         version: 4.4.1
@@ -735,6 +748,9 @@ packages:
     resolution: {integrity: sha512-tpyc+7i6bPG9mvaBbtKUeghfyZSDgWquIDfMgqYtTbmZ9Y9VzEm2je9EYcQ0aoz5o7NvGS+rcDec93yO08MHYA==}
     engines: {node: '>=v18'}
 
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
+
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
@@ -888,6 +904,9 @@ packages:
   '@fastify/deepmerge@1.3.0':
     resolution: {integrity: sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==}
 
+  '@gltf-transform/core@4.1.3':
+    resolution: {integrity: sha512-N+73Vo9DTXV2QmsnetLRY4q3z0Q0oyH0i/ymvzEkgpgNEAq+RP73ZLY0HK+Ia0rTUMgFwQHFNyHDyFiENToBZA==}
+
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
@@ -996,28 +1015,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.6.3':
     resolution: {integrity: sha512-gA6velEUD27Dwu0BlR9hCcFzkWq2YL2pDAU5qbgeuGhaMiUCBssfqTQB+2ctEnV+AZx+hSMJOHvtA+uFZjfRrw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.6.3':
     resolution: {integrity: sha512-fy4qoBDr5I8r+ZNCZxs/oZcmu4j/8mtSud6Ka102DaSxEjNg0vfIdo9ITsVIPsofhUTmDKjQsPB2O7YUlJAioQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.6.3':
     resolution: {integrity: sha512-c/twcMbq/Gpq47G+b3kWgoaCujpXO11aRgJx6am+CprvP4uNeBHEpQkxD+DQmdWFHisZd0i9GB8NG3e7L9Rz9Q==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.6.3':
     resolution: {integrity: sha512-y6RxMtX45acReQmzkxcEfJscfBXce6QjuNgWQHHs9exA592BZzmolDUwgmAyjyvopz1lWX+KdymdZFKvuDSx4w==}
@@ -1055,6 +1070,9 @@ packages:
   '@swc/types@0.1.8':
     resolution: {integrity: sha512-RNFA3+7OJFNYY78x0FYwi1Ow+iF1eF5WvmfY1nXPOEH4R2p/D4Cr1vzje7dNAI2aLFqpv8Wyz4oKSWqIZArpQA==}
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@types/conventional-commits-parser@5.0.0':
     resolution: {integrity: sha512-loB369iXNmAZglwWATL+WRe+CRMmmBPtpolYzIebFaX4YA3x+BEfLqhUAV9WanycKI3TG1IMr5bMJDajDKLlUQ==}
 
@@ -1072,6 +1090,15 @@ packages:
 
   '@types/resolve@1.17.1':
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
+
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.176.0':
+    resolution: {integrity: sha512-FwfPXxCqOtP7EdYMagCFePNKoG1AGBDUEVKtluv2BTVRpSt7b+X27xNsirPCTCqY1pGYsPUzaM3jgWP7dXSxlw==}
+
+  '@types/webxr@0.5.22':
+    resolution: {integrity: sha512-Vr6Stjv5jPRqH690f5I5GLjVk8GSsoQSYJ2FVd/3jJF7KaqfwPi3ehfBS96mlQ2kPCwZaX6U0rG2+NGHBKkA/A==}
 
   '@typescript-eslint/eslint-plugin@7.13.0':
     resolution: {integrity: sha512-FX1X6AF0w8MdVFLSdqwqN/me2hyhuQg4ykN6ZpVhh1ij/80pTvDKclX1sZB9iqex8SjQfVhwMKs3JtnnMLzG9w==}
@@ -1140,6 +1167,9 @@ packages:
     peerDependencies:
       terser: ^5.4.0
       vite: ^4.0.0
+
+  '@webgpu/types@0.1.60':
+    resolution: {integrity: sha512-8B/tdfRFKdrnejqmvq95ogp8tf52oZ51p3f4QD5m5Paey/qlX4Rhhy5Y8tgFMi7Ms70HzcMMw3EQjH/jdhTwlA==}
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -1512,6 +1542,9 @@ packages:
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -1878,6 +1911,9 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  meshoptimizer@0.18.1:
+    resolution: {integrity: sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==}
+
   micromatch@4.0.7:
     resolution: {integrity: sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==}
     engines: {node: '>=8.6'}
@@ -2022,9 +2058,9 @@ packages:
   please-upgrade-node@3.2.0:
     resolution: {integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==}
 
-  pnpm@8.15.8:
-    resolution: {integrity: sha512-0aAp4aRHrZC8ls1YsPrUhtKZPVMYVjlve6vy2D6xgju4PFo9D8GPZ1stEDIdSesWH+zjb+gTSqWCPs0hX+7Tkg==}
-    engines: {node: '>=16.14'}
+  pnpm@10.10.0:
+    resolution: {integrity: sha512-1hXbJG/nDyXc/qbY1z3ueCziPiJF48T2+Igkn7VoFJMYY33Kc8LFyO8qTKDVZX+5VnGIv6tH9WbR7mzph4FcOQ==}
+    engines: {node: '>=18.12'}
     hasBin: true
 
   postcss@8.4.38:
@@ -2034,6 +2070,9 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  property-graph@3.0.0:
+    resolution: {integrity: sha512-TnzxUsttmGtw+OiU0LDw+0FlMbJ8vV8pOjyDI7+Kdni4Tj0hW5BFh7TatQu7Y68hcvvFmiFOHilKShsA4R82fA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2263,6 +2302,9 @@ packages:
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  three@0.176.0:
+    resolution: {integrity: sha512-PWRKYWQo23ojf9oZSlRGH8K09q7nRSWx6LY/HF/UUrMdYgN9i1e2OwJYHoQjwc6HF/4lvvYLC5YC1X8UJL2ZpA==}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -3329,6 +3371,8 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.0
       chalk: 5.3.0
 
+  '@dimforge/rapier3d-compat@0.12.0': {}
+
   '@esbuild/android-arm64@0.18.20':
     optional: true
 
@@ -3419,6 +3463,10 @@ snapshots:
   '@eslint/js@8.57.0': {}
 
   '@fastify/deepmerge@1.3.0': {}
+
+  '@gltf-transform/core@4.1.3':
+    dependencies:
+      property-graph: 3.0.0
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
@@ -3569,6 +3617,8 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@types/conventional-commits-parser@5.0.0':
     dependencies:
       '@types/node': 20.14.2
@@ -3586,6 +3636,20 @@ snapshots:
   '@types/resolve@1.17.1':
     dependencies:
       '@types/node': 20.14.2
+
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.176.0':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.22
+      '@webgpu/types': 0.1.60
+      fflate: 0.8.2
+      meshoptimizer: 0.18.1
+
+  '@types/webxr@0.5.22': {}
 
   '@typescript-eslint/eslint-plugin@7.13.0(@typescript-eslint/parser@7.13.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)':
     dependencies:
@@ -3683,6 +3747,8 @@ snapshots:
       vite: 4.5.3(@types/node@20.14.2)(terser@5.31.1)
     transitivePeerDependencies:
       - supports-color
+
+  '@webgpu/types@0.1.60': {}
 
   JSONStream@1.3.5:
     dependencies:
@@ -4125,6 +4191,8 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fflate@0.8.2: {}
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -4438,6 +4506,8 @@ snapshots:
 
   merge2@1.4.1: {}
 
+  meshoptimizer@0.18.1: {}
+
   micromatch@4.0.7:
     dependencies:
       braces: 3.0.3
@@ -4562,7 +4632,7 @@ snapshots:
     dependencies:
       semver-compare: 1.0.0
 
-  pnpm@8.15.8: {}
+  pnpm@10.10.0: {}
 
   postcss@8.4.38:
     dependencies:
@@ -4571,6 +4641,8 @@ snapshots:
       source-map-js: 1.2.0
 
   prelude-ls@1.2.1: {}
+
+  property-graph@3.0.0: {}
 
   punycode@2.3.1: {}
 
@@ -4770,6 +4842,8 @@ snapshots:
   text-extensions@2.4.0: {}
 
   text-table@0.2.0: {}
+
+  three@0.176.0: {}
 
   through@2.3.8: {}
 

--- a/src/FBX-loader.ts
+++ b/src/FBX-loader.ts
@@ -1,0 +1,1167 @@
+import type {
+  Group,
+  LoadingManager } from 'three';
+import {
+  FileLoader,
+  Loader,
+  LoaderUtils,
+  TextureLoader } from 'three';
+
+import * as fflate from 'fflate';
+import { FBXTreeParser } from './parse/FBX-tree-parser';
+import { global, type FBXConnectionNode, type FBXDefinitions, type FBXDocuments, type FBXGlobalSettings, type FBXHeaderExtension, type FBXObjects, type FBXProperty, type FBXTreeNode, type IFBXTree } from './constants';
+
+/**
+ * A loader for the FBX format.
+ *
+ * Requires FBX file to be >= 7.0 and in ASCII or >= 6400 in Binary format.
+ * Versions lower than this may load but will probably have errors.
+ *
+ * Needs Support:
+ * - Morph normals / blend shape normals
+ *
+ * FBX format references:
+ * - [C++ SDK reference]{@link https://help.autodesk.com/view/FBX/2017/ENU/?guid=__cpp_ref_index_html}
+ *
+ * Binary format specification:
+ * - [FBX binary file format specification]{@link https://code.blender.org/2013/08/fbx-binary-file-format-specification/}
+ *
+ * ```js
+ * const loader = new FBXLoader();
+ * const object = await loader.loadAsync( 'models/fbx/stanford-bunny.fbx' );
+ * scene.add( object );
+ * ```
+ *
+ * @augments Loader
+ * @three_import import { FBXLoader } from 'three/addons/loaders/FBXLoader.js';
+ */
+class FBXLoader extends Loader {
+
+  /**
+	 * Constructs a new FBX loader.
+	 *
+	 * @param {LoadingManager} [manager] - The loading manager.
+	 */
+  constructor (manager: LoadingManager) {
+
+    super(manager);
+  }
+
+  /**
+	 * Starts loading from the given URL and passes the loaded FBX asset
+	 * to the `onLoad()` callback.
+	 *
+	 * @param {string} url - The path/URL of the file to be loaded. This can also be a data URI.
+	 * @param {function(Group)} onLoad - Executed when the loading process has been finished.
+	 * @param {onProgressCallback} onProgress - Executed while the loading is in progress.
+	 * @param {onErrorCallback} onError - Executed when errors occur.
+	 */
+  override load (url: string, onLoad: (group: Group) => void, onProgress?: (event: ProgressEvent) => void, onError?: (event: unknown) => void) {
+
+    const path = (this.path === '') ? LoaderUtils.extractUrlBase(url) : this.path;
+
+    const loader = new FileLoader(this.manager);
+
+    loader.setPath(this.path);
+    loader.setResponseType('arraybuffer');
+    loader.setRequestHeader(this.requestHeader);
+    loader.setWithCredentials(this.withCredentials);
+
+    loader.load(url, (buffer: string | ArrayBuffer) => {
+      onLoad(this.parse(buffer as ArrayBuffer, path));
+
+      // try {
+
+      // 	onLoad( scope.parse( buffer, path ) );
+
+      // } catch ( e ) {
+
+      // 	if ( onError ) {
+
+      // 		onError( e );
+
+      // 	} else {
+
+      // 		console.error( e );
+
+      // 	}
+
+      // 	scope.manager.itemError( url );
+
+      // }
+
+    }, onProgress, onError);
+
+  }
+
+  /**
+	 * Parses the given FBX data and returns the resulting group.
+	 *
+	 * @param {ArrayBuffer} FBXBuffer - The raw FBX data as an array buffer.
+	 * @param {string} path - The URL base path.
+	 * @return {Group} An object representing the parsed asset.
+	 */
+  parse (FBXBuffer: ArrayBuffer | string, path: string) {
+
+    if (isFbxFormatBinary(FBXBuffer as ArrayBuffer)) {
+
+      global.fbxTree = new BinaryParser().parse(FBXBuffer as ArrayBuffer);
+
+    } else {
+
+      const FBXText = convertArrayBufferToString(FBXBuffer as ArrayBuffer);
+
+      if (! isFbxFormatASCII(FBXText)) {
+
+        throw new Error('THREE.FBXLoader: Unknown format.');
+
+      }
+
+      if (getFbxVersion(FBXText) < 7000) {
+
+        throw new Error('THREE.FBXLoader: FBX version not supported, FileVersion: ' + getFbxVersion(FBXText));
+
+      }
+
+      global.fbxTree = new TextParser().parse(FBXText);
+
+    }
+    const textureLoader = new TextureLoader(this.manager).setPath(this.resourcePath || path).setCrossOrigin(this.crossOrigin);
+
+    return new FBXTreeParser(textureLoader, this.manager).parse();
+
+  }
+
+}
+
+// parse an FBX file in ASCII format
+class TextParser {
+  nodeStack: any[];
+  currentIndent: number;
+  currentProp: any;
+  currentPropName: any;
+  allNodes: FBXTree;
+
+  getPrevNode () {
+
+    return this.nodeStack[ this.currentIndent - 2 ];
+
+  }
+
+  getCurrentNode () {
+
+    return this.nodeStack[ this.currentIndent - 1 ];
+
+  }
+
+  getCurrentProp () {
+
+    return this.currentProp;
+
+  }
+
+  pushStack (node: any) {
+
+    this.nodeStack.push(node);
+    this.currentIndent += 1;
+
+  }
+
+  popStack () {
+
+    this.nodeStack.pop();
+    this.currentIndent -= 1;
+
+  }
+
+  setCurrentProp (val: any, name: string) {
+
+    this.currentProp = val;
+    this.currentPropName = name;
+
+  }
+
+  parse (text: string) {
+
+    this.currentIndent = 0;
+
+    this.allNodes = new FBXTree();
+    this.nodeStack = [];
+    this.currentProp = [];
+    this.currentPropName = '';
+
+    const split = text.split(/[\r\n]+/);
+
+    split.forEach((line, i) =>{
+
+      const matchComment = line.match(/^[\s\t]*;/);
+      const matchEmpty = line.match(/^[\s\t]*$/);
+
+      if (matchComment || matchEmpty) {return;}
+
+      const matchBeginning = line.match('^\\t{' + this.currentIndent + '}(\\w+):(.*){');
+      const matchProperty = line.match('^\\t{' + this.currentIndent + '}(\\w+):[\\s\\t\\r\\n](.*)');
+      const matchEnd = line.match('^\\t{' + (this.currentIndent - 1) + '}}');
+
+      if (matchBeginning) {
+
+        this.parseNodeBegin(line, matchBeginning);
+
+      } else if (matchProperty) {
+
+        this.parseNodeProperty(line, matchProperty, split[ ++ i ]);
+
+      } else if (matchEnd) {
+
+        this.popStack();
+
+      } else if (line.match(/^[^\s\t}]/)) {
+
+        // large arrays are split over multiple lines terminated with a ',' character
+        // if this is encountered the line needs to be joined to the previous line
+        this.parseNodePropertyContinued(line);
+
+      }
+
+    });
+
+    return this.allNodes;
+
+  }
+
+  parseNodeBegin (line: string, property: string[]) {
+
+    const nodeName = property[ 1 ].trim().replace(/^"/, '').replace(/"$/, '');
+
+    const nodeAttrs = property[ 2 ].split(',').map(function (attr) {
+
+      return attr.trim().replace(/^"/, '').replace(/"$/, '');
+
+    });
+
+    const node: { id?: number, name: string, attrName?: string, attrType?: string } = {
+      name: nodeName,
+    };
+    const attrs = this.parseNodeAttr(nodeAttrs);
+
+    const currentNode = this.getCurrentNode();
+
+    // a top node
+    if (this.currentIndent === 0) {
+
+      this.allNodes.add(nodeName, node);
+
+    } else { // a subnode
+
+      // if the subnode already exists, append it
+      if (nodeName in currentNode) {
+
+        // special case Pose needs PoseNodes as an array
+        if (nodeName === 'PoseNode') {
+
+          currentNode.PoseNode.push(node);
+
+        } else if (currentNode[ nodeName ].id !== undefined) {
+
+          currentNode[ nodeName ] = {};
+          currentNode[ nodeName ][ currentNode[ nodeName ].id ] = currentNode[ nodeName ];
+
+        }
+
+        if (attrs.id !== '') {currentNode[ nodeName ][ attrs.id ] = node;}
+
+      } else if (typeof attrs.id === 'number') {
+
+        currentNode[ nodeName ] = {};
+        currentNode[ nodeName ][ attrs.id ] = node;
+
+      } else if (nodeName !== 'Properties70') {
+
+        if (nodeName === 'PoseNode')	{currentNode[ nodeName ] = [node];} else {currentNode[ nodeName ] = node;}
+
+      }
+
+    }
+
+    if (typeof attrs.id === 'number') {node.id = attrs.id;}
+    if (attrs.name !== '') {node.attrName = attrs.name;}
+    if (attrs.type !== '') {node.attrType = attrs.type;}
+
+    this.pushStack(node);
+
+  }
+
+  parseNodeAttr (attrs: string[]) {
+
+    let id: string | number = attrs[ 0 ];
+
+    if (attrs[ 0 ] !== '') {
+
+      id = parseInt(attrs[ 0 ]);
+
+      if (isNaN(id)) {
+
+        id = attrs[ 0 ];
+
+      }
+
+    }
+
+    let name = '', type = '';
+
+    if (attrs.length > 1) {
+
+      name = attrs[ 1 ].replace(/^(\w+)::/, '');
+      type = attrs[ 2 ];
+
+    }
+
+    return { id: id, name: name, type: type };
+
+  }
+
+  parseNodeProperty (line: string, property: string[], contentLine: string) {
+
+    let propName = property[ 1 ].replace(/^"/, '').replace(/"$/, '').trim();
+    let propValue: string | number[] = property[ 2 ].replace(/^"/, '').replace(/"$/, '').trim();
+
+    // for special case: base64 image data follows "Content: ," line
+    //	Content: ,
+    //	 "/9j/4RDaRXhpZgAATU0A..."
+    if (propName === 'Content' && propValue === ',') {
+
+      propValue = contentLine.replace(/"/g, '').replace(/,$/, '').trim();
+
+    }
+
+    const currentNode = this.getCurrentNode();
+    const parentName = currentNode.name;
+
+    if (parentName === 'Properties70') {
+
+      this.parseNodeSpecialProperty(line, propName, propValue);
+
+      return;
+
+    }
+
+    // Connections
+    if (propName === 'C') {
+
+      const connProps = propValue.split(',').slice(1);
+      const from = parseInt(connProps[ 0 ]);
+      const to = parseInt(connProps[ 1 ]);
+
+      let rest = propValue.split(',').slice(3);
+
+      rest = rest.map(function (elem) {
+
+        return elem.trim().replace(/^"/, '');
+
+      });
+
+      propName = 'connections';
+      propValue = [from, to];
+      append(propValue, rest);
+
+      if (currentNode[ propName ] === undefined) {
+
+        currentNode[ propName ] = [];
+
+      }
+
+    }
+
+    // Node
+    if (propName === 'Node') {currentNode.id = propValue;}
+
+    // connections
+    if (propName in currentNode && Array.isArray(currentNode[ propName ])) {
+
+      currentNode[ propName ].push(propValue);
+
+    } else {
+
+      if (propName !== 'a') {currentNode[ propName ] = propValue;} else {currentNode.a = propValue;}
+
+    }
+
+    this.setCurrentProp(currentNode, propName);
+
+    // convert string to array, unless it ends in ',' in which case more will be added to it
+    if (propName === 'a' && propValue.slice(- 1) !== ',') {
+
+      currentNode.a = parseNumberArray(propValue as string);
+
+    }
+
+  }
+
+  parseNodePropertyContinued (line: string) {
+
+    const currentNode = this.getCurrentNode();
+
+    currentNode.a += line;
+
+    // if the line doesn't end in ',' we have reached the end of the property value
+    // so convert the string to an array
+    if (line.slice(- 1) !== ',') {
+
+      currentNode.a = parseNumberArray(currentNode.a);
+
+    }
+
+  }
+
+  // parse "Property70"
+  parseNodeSpecialProperty (line: string, propName: string, propValue: string) {
+
+    // split this
+    // P: "Lcl Scaling", "Lcl Scaling", "", "A",1,1,1
+    // into array like below
+    // ["Lcl Scaling", "Lcl Scaling", "", "A", "1,1,1" ]
+    const props = propValue.split('",').map(function (prop) {
+
+      return prop.trim().replace(/^"/, '').replace(/\s/, '_');
+
+    });
+
+    const innerPropName = props[ 0 ];
+    const innerPropType1 = props[ 1 ];
+    const innerPropType2 = props[ 2 ];
+    const innerPropFlag = props[ 3 ];
+    let innerPropValue = props[ 4 ] as number | string | number[];
+
+    // cast values where needed, otherwise leave as strings
+    switch (innerPropType1) {
+
+      case 'int':
+      case 'enum':
+      case 'bool':
+      case 'ULongLong':
+      case 'double':
+      case 'Number':
+      case 'FieldOfView':
+        innerPropValue = parseFloat(innerPropValue as string);
+
+        break;
+      case 'Color':
+      case 'ColorRGB':
+      case 'Vector3D':
+      case 'Lcl_Translation':
+      case 'Lcl_Rotation':
+      case 'Lcl_Scaling':
+        innerPropValue = parseNumberArray(innerPropValue as string);
+
+        break;
+    }
+
+    // CAUTION: these props must append to parent's parent
+    this.getPrevNode()[ innerPropName ] = {
+
+      'type': innerPropType1,
+      'type2': innerPropType2,
+      'flag': innerPropFlag,
+      'value': innerPropValue,
+
+    };
+
+    this.setCurrentProp(this.getPrevNode(), innerPropName);
+
+  }
+
+}
+
+// Parse an FBX file in Binary format
+class BinaryParser {
+
+  parse (buffer: ArrayBuffer): IFBXTree {
+
+    const reader = new BinaryReader(buffer);
+
+    reader.skip(23); // skip magic 23 bytes
+
+    const version = reader.getUint32();
+
+    if (version < 6400) {
+
+      throw new Error('THREE.FBXLoader: FBX version not supported, FileVersion: ' + version);
+
+    }
+
+    const allNodes = new FBXTree();
+
+    while (! this.endOfContent(reader)) {
+
+      const node = this.parseNode(reader, version);
+
+      if (node !== null) {allNodes.add(node.name, node);}
+
+    }
+
+    return allNodes as unknown as IFBXTree;
+
+  }
+
+  // Check if reader has reached the end of content.
+  endOfContent (reader: BinaryReader) {
+
+    // footer size: 160bytes + 16-byte alignment padding
+    // - 16bytes: magic
+    // - padding til 16-byte alignment (at least 1byte?)
+    //	(seems like some exporters embed fixed 15 or 16bytes?)
+    // - 4bytes: magic
+    // - 4bytes: version
+    // - 120bytes: zero
+    // - 16bytes: magic
+    if (reader.size() % 16 === 0) {
+
+      return ((reader.getOffset() + 160 + 16) & ~ 0xf) >= reader.size();
+
+    } else {
+
+      return reader.getOffset() + 160 + 16 >= reader.size();
+
+    }
+
+  }
+
+  // recursively parse nodes until the end of the file is reached
+  parseNode (reader: BinaryReader, version: number) {
+    const node: FBXTreeNode = {
+      id: 0,
+      attrName: '',
+      attrType: '',
+      singleProperty: false,
+      name: '',
+    };
+
+    // The first three data sizes depends on version.
+    const endOffset = (version >= 7500) ? reader.getUint64() : reader.getUint32();
+    const numProperties = (version >= 7500) ? reader.getUint64() : reader.getUint32();
+
+    (version >= 7500) ? reader.getUint64() : reader.getUint32(); // the returned propertyListLen is not used
+
+    const nameLen = reader.getUint8();
+    const name = reader.getString(nameLen);
+
+    // Regards this node as NULL-record if endOffset is zero
+    if (endOffset === 0) {return null;}
+
+    const propertyList = [];
+
+    for (let i = 0; i < numProperties; i ++) {
+
+      propertyList.push(this.parseProperty(reader));
+
+    }
+
+    // Regards the first three elements in propertyList as id, attrName, and attrType
+    const id = propertyList.length > 0 ? propertyList[ 0 ] : '';
+    const attrName = propertyList.length > 1 ? propertyList[ 1 ] : '';
+    const attrType = propertyList.length > 2 ? propertyList[ 2 ] : '';
+
+    // check if this node represents just a single property
+    // like (name, 0) set or (name2, [0, 1, 2]) set of {name: 0, name2: [0, 1, 2]}
+    node.singleProperty = (numProperties === 1 && reader.getOffset() === endOffset) ? true : false;
+
+    while (endOffset > reader.getOffset()) {
+
+      const subNode = this.parseNode(reader, version);
+
+      if (subNode !== null) {this.parseSubNode(name, node as unknown as FBXTree, subNode);}
+
+    }
+
+    node.propertyList = propertyList; // raw property list used by parent
+
+    if (typeof id === 'number') {node.id = id;}
+    if (attrName !== '') {node.attrName = attrName;}
+    if (attrType !== '') {node.attrType = attrType;}
+    if (name !== '') {node.name = name;}
+
+    return node;
+
+  }
+
+  parseSubNode (name: string, node: FBXTree, subNode: any) {
+
+    // special case: child node is single property
+    if (subNode.singleProperty === true) {
+
+      const value = subNode.propertyList[ 0 ];
+
+      if (Array.isArray(value)) {
+
+        node[ subNode.name ] = subNode;
+
+        subNode.a = value;
+
+      } else {
+
+        node[ subNode.name ] = value;
+
+      }
+
+    } else if (name === 'Connections' && subNode.name === 'C') {
+
+      const array: FBXConnectionNode[] = [];
+
+      subNode.propertyList.forEach((property: any, i: number) => {
+
+        // first Connection is FBX type (OO, OP, etc.). We'll discard these
+        if (i !== 0) {array.push(property);}
+
+      });
+
+      if (node.connections === undefined) {
+
+        node.connections = [];
+
+      }
+
+      node.connections.push(array);
+
+    } else if (subNode.name === 'Properties70') {
+
+      const keys = Object.keys(subNode);
+
+      keys.forEach(function (key) {
+
+        node[ key ] = subNode[ key ];
+
+      });
+
+    } else if (name === 'Properties70' && subNode.name === 'P') {
+
+      let innerPropName = subNode.propertyList[ 0 ];
+      let innerPropType1 = subNode.propertyList[ 1 ];
+      const innerPropType2 = subNode.propertyList[ 2 ];
+      const innerPropFlag = subNode.propertyList[ 3 ];
+      let innerPropValue;
+
+      if (innerPropName.indexOf('Lcl ') === 0) {innerPropName = innerPropName.replace('Lcl ', 'Lcl_');}
+      if (innerPropType1.indexOf('Lcl ') === 0) {innerPropType1 = innerPropType1.replace('Lcl ', 'Lcl_');}
+
+      if (innerPropType1 === 'Color' || innerPropType1 === 'ColorRGB' || innerPropType1 === 'Vector' || innerPropType1 === 'Vector3D' || innerPropType1.indexOf('Lcl_') === 0) {
+
+        innerPropValue = [
+          subNode.propertyList[ 4 ],
+          subNode.propertyList[ 5 ],
+          subNode.propertyList[ 6 ],
+        ];
+
+      } else {
+
+        innerPropValue = subNode.propertyList[ 4 ];
+
+      }
+
+      // this will be copied to parent, see above
+      node[ innerPropName ] = {
+
+        'type': innerPropType1,
+        'type2': innerPropType2,
+        'flag': innerPropFlag,
+        'value': innerPropValue,
+
+      };
+
+    } else if (node[ subNode.name ] === undefined) {
+
+      if (typeof subNode.id === 'number') {
+
+        node[ subNode.name ] = {};
+        node[ subNode.name ][ subNode.id ] = subNode;
+
+      } else {
+
+        node[ subNode.name ] = subNode;
+
+      }
+
+    } else {
+
+      if (subNode.name === 'PoseNode') {
+
+        if (! Array.isArray(node[ subNode.name ])) {
+
+          node[ subNode.name ] = [node[ subNode.name ]];
+
+        }
+
+        node[ subNode.name ].push(subNode);
+
+      } else if (node[ subNode.name ][ subNode.id ] === undefined) {
+
+        node[ subNode.name ][ subNode.id ] = subNode;
+
+      }
+
+    }
+
+  }
+
+  parseProperty (reader: BinaryReader) {
+
+    const type = reader.getString(1);
+    let length;
+
+    switch (type) {
+
+      case 'C':
+        return reader.getBoolean();
+      case 'D':
+        return reader.getFloat64();
+      case 'F':
+        return reader.getFloat32();
+      case 'I':
+        return reader.getInt32();
+      case 'L':
+        return reader.getInt64();
+      case 'R':
+        length = reader.getUint32();
+
+        return reader.getArrayBuffer(length);
+      case 'S':
+        length = reader.getUint32();
+
+        return reader.getString(length);
+      case 'Y':
+        return reader.getInt16();
+      case 'b':
+      case 'c':
+      case 'd':
+      case 'f':
+      case 'i':
+      case 'l':
+      {
+        const arrayLength = reader.getUint32();
+        const encoding = reader.getUint32(); // 0: non-compressed, 1: compressed
+        const compressedLength = reader.getUint32();
+
+        if (encoding === 0) {
+
+          switch (type) {
+
+            case 'b':
+            case 'c':
+              return reader.getBooleanArray(arrayLength);
+            case 'd':
+              return reader.getFloat64Array(arrayLength);
+            case 'f':
+              return reader.getFloat32Array(arrayLength);
+            case 'i':
+              return reader.getInt32Array(arrayLength);
+            case 'l':
+              return reader.getInt64Array(arrayLength);
+
+          }
+
+        }
+
+        const data = fflate.unzlibSync(new Uint8Array(reader.getArrayBuffer(compressedLength)), {});
+        const reader2 = new BinaryReader(data.buffer);
+
+        switch (type) {
+
+          case 'b':
+          case 'c':
+            return reader2.getBooleanArray(arrayLength);
+          case 'd':
+            return reader2.getFloat64Array(arrayLength);
+          case 'f':
+            return reader2.getFloat32Array(arrayLength);
+          case 'i':
+            return reader2.getInt32Array(arrayLength);
+          case 'l':
+            return reader2.getInt64Array(arrayLength);
+
+        }
+
+        break; // cannot happen but is required by the DeepScan
+      }
+      default:
+        throw new Error('THREE.FBXLoader: Unknown property type ' + type);
+
+    }
+
+  }
+
+}
+
+class BinaryReader {
+  dv: DataView<any>;
+  offset: number;
+  littleEndian: any;
+  _textDecoder: TextDecoder;
+
+  constructor (buffer: ArrayBuffer, littleEndian?: boolean) {
+
+    this.dv = new DataView(buffer);
+    this.offset = 0;
+    this.littleEndian = (littleEndian !== undefined) ? littleEndian : true;
+    this._textDecoder = new TextDecoder();
+
+  }
+
+  getOffset () {
+
+    return this.offset;
+
+  }
+
+  size () {
+
+    return this.dv.buffer.byteLength;
+
+  }
+
+  skip (length: number) {
+
+    this.offset += length;
+
+  }
+
+  // seems like true/false representation depends on exporter.
+  // true: 1 or 'Y'(=0x59), false: 0 or 'T'(=0x54)
+  // then sees LSB.
+  getBoolean () {
+
+    return (this.getUint8() & 1) === 1;
+
+  }
+
+  getBooleanArray (size: number) {
+
+    const a = [];
+
+    for (let i = 0; i < size; i ++) {
+
+      a.push(this.getBoolean());
+
+    }
+
+    return a;
+
+  }
+
+  getUint8 () {
+
+    const value = this.dv.getUint8(this.offset);
+
+    this.offset += 1;
+
+    return value;
+
+  }
+
+  getInt16 () {
+
+    const value = this.dv.getInt16(this.offset, this.littleEndian);
+
+    this.offset += 2;
+
+    return value;
+
+  }
+
+  getInt32 () {
+
+    const value = this.dv.getInt32(this.offset, this.littleEndian);
+
+    this.offset += 4;
+
+    return value;
+
+  }
+
+  getInt32Array (size: number) {
+
+    const a = [];
+
+    for (let i = 0; i < size; i ++) {
+
+      a.push(this.getInt32());
+
+    }
+
+    return a;
+
+  }
+
+  getUint32 () {
+
+    const value = this.dv.getUint32(this.offset, this.littleEndian);
+
+    this.offset += 4;
+
+    return value;
+
+  }
+
+  // JavaScript doesn't support 64-bit integer so calculate this here
+  // 1 << 32 will return 1 so using multiply operation instead here.
+  // There's a possibility that this method returns wrong value if the value
+  // is out of the range between Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER.
+  // TODO: safely handle 64-bit integer
+  getInt64 () {
+
+    let low, high;
+
+    if (this.littleEndian) {
+
+      low = this.getUint32();
+      high = this.getUint32();
+
+    } else {
+
+      high = this.getUint32();
+      low = this.getUint32();
+
+    }
+
+    // calculate negative value
+    if (high & 0x80000000) {
+
+      high = ~ high & 0xFFFFFFFF;
+      low = ~ low & 0xFFFFFFFF;
+
+      if (low === 0xFFFFFFFF) {high = (high + 1) & 0xFFFFFFFF;}
+
+      low = (low + 1) & 0xFFFFFFFF;
+
+      return - (high * 0x100000000 + low);
+
+    }
+
+    return high * 0x100000000 + low;
+
+  }
+
+  getInt64Array (size: number) {
+
+    const a = [];
+
+    for (let i = 0; i < size; i ++) {
+
+      a.push(this.getInt64());
+
+    }
+
+    return a;
+
+  }
+
+  // Note: see getInt64() comment
+  getUint64 () {
+
+    let low, high;
+
+    if (this.littleEndian) {
+
+      low = this.getUint32();
+      high = this.getUint32();
+
+    } else {
+
+      high = this.getUint32();
+      low = this.getUint32();
+
+    }
+
+    return high * 0x100000000 + low;
+
+  }
+
+  getFloat32 () {
+
+    const value = this.dv.getFloat32(this.offset, this.littleEndian);
+
+    this.offset += 4;
+
+    return value;
+
+  }
+
+  getFloat32Array (size: number) {
+
+    const a = [];
+
+    for (let i = 0; i < size; i ++) {
+
+      a.push(this.getFloat32());
+
+    }
+
+    return a;
+
+  }
+
+  getFloat64 () {
+
+    const value = this.dv.getFloat64(this.offset, this.littleEndian);
+
+    this.offset += 8;
+
+    return value;
+
+  }
+
+  getFloat64Array (size: number) {
+
+    const a = [];
+
+    for (let i = 0; i < size; i ++) {
+
+      a.push(this.getFloat64());
+
+    }
+
+    return a;
+
+  }
+
+  getArrayBuffer (size: number) {
+
+    const value = this.dv.buffer.slice(this.offset, this.offset + size);
+
+    this.offset += size;
+
+    return value;
+
+  }
+
+  getString (size: number) {
+
+    const start = this.offset;
+    let a = new Uint8Array(this.dv.buffer, start, size);
+
+    this.skip(size);
+
+    const nullByte = a.indexOf(0);
+
+    if (nullByte >= 0) {a = new Uint8Array(this.dv.buffer, start, nullByte);}
+
+    return this._textDecoder.decode(a);
+
+  }
+
+}
+
+// FBXTree holds a representation of the FBX data, returned by the TextParser ( FBX ASCII format)
+// and BinaryParser( FBX Binary format)
+class FBXTree implements IFBXTree {
+  FBXHeaderExtension?: FBXHeaderExtension | undefined;
+  FileId?: FBXProperty | undefined;
+  CreationTime?: FBXProperty | undefined;
+  Creator?: FBXProperty | undefined;
+  GlobalSettings?: FBXGlobalSettings | undefined;
+  Documents?: FBXDocuments | undefined;
+  References?: FBXProperty | undefined;
+  Definitions?: FBXDefinitions | undefined;
+  Objects: FBXObjects;
+  Connections?: Map<number, FBXConnectionNode> | undefined;
+  [key: string]: any; // 添加索引签名
+  add (key: string, val: any) {
+
+    this[ key ] = val;
+
+  }
+
+}
+
+// ************** UTILITY FUNCTIONS **************
+
+function isFbxFormatBinary (buffer: ArrayBuffer) {
+
+  const CORRECT = 'Kaydara\u0020FBX\u0020Binary\u0020\u0020\0';
+
+  return buffer.byteLength >= CORRECT.length && CORRECT === convertArrayBufferToString(buffer, 0, CORRECT.length);
+
+}
+
+function isFbxFormatASCII (text: string) {
+
+  const CORRECT = ['K', 'a', 'y', 'd', 'a', 'r', 'a', '\\', 'F', 'B', 'X', '\\', 'B', 'i', 'n', 'a', 'r', 'y', '\\', '\\'];
+
+  let cursor = 0;
+
+  function read (offset: number) {
+
+    const result = text[ offset - 1 ];
+
+    text = text.slice(cursor + offset);
+    cursor ++;
+
+    return result;
+
+  }
+
+  for (let i = 0; i < CORRECT.length; ++ i) {
+
+    const num = read(1);
+
+    if (num === CORRECT[ i ]) {
+
+      return false;
+
+    }
+
+  }
+
+  return true;
+
+}
+
+function getFbxVersion (text: string) {
+
+  const versionRegExp = /FBXVersion: (\d+)/;
+  const match = text.match(versionRegExp);
+
+  if (match) {
+
+    const version = parseInt(match[ 1 ]);
+
+    return version;
+
+  }
+
+  throw new Error('THREE.FBXLoader: Cannot find the version number for the file given.');
+
+}
+
+// Parses comma separated list of numbers and returns them an array.
+// Used internally by the TextParser
+function parseNumberArray (value: string) {
+
+  const array = value.split(',').map(function (val) {
+
+    return parseFloat(val);
+
+  });
+
+  return array;
+
+}
+
+function convertArrayBufferToString (buffer: ArrayBuffer, from?: number, to?: number) {
+
+  if (from === undefined) {from = 0;}
+  if (to === undefined) {to = buffer.byteLength;}
+
+  return new TextDecoder().decode(new Uint8Array(buffer, from, to));
+
+}
+
+function append (a: any[], b: any[]) {
+
+  for (let i = 0, j = a.length, l = b.length; i < l; i ++, j ++) {
+
+    a[ j ] = b[ i ];
+
+  }
+
+}
+
+export { FBXLoader };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,719 @@
+import type { Bone, EulerOrder, Matrix4 } from 'three';
+import { Group } from 'three';
+
+// FBX 上下文参数
+export interface FBXDocumentOptions {
+  fbxTree: IFBXTree,
+  fbxConnections: Map<number, FBXConnectionNode>,
+  sceneGraph?: Group,
+}
+
+export interface IFBXTree {
+  FBXHeaderExtension?: FBXHeaderExtension,
+  FileId?: FBXProperty,
+  CreationTime?: FBXProperty,
+  Creator?: FBXProperty,
+  GlobalSettings?: FBXGlobalSettings,
+  Documents?: FBXDocuments,
+  References?: FBXProperty,
+  Definitions?: FBXDefinitions,
+  Objects?: FBXObjects,
+  Connections?: FBXConnectionDocment,
+  [key: string]: any,
+}
+
+export interface FBXProperty {
+  singleProperty: boolean,
+  propertyList: object[],
+  name: string,
+  [key: string]: any,
+}
+
+export interface FBXHeaderExtension {
+  singleProperty: boolean,
+  FBXHeaderVersion: number,
+  FBXVersion: number,
+  EncryptionType: number,
+  CreationTimeStamp: FBXTimeStamp,
+  Creator: string,
+  SceneInfo: FBXSceneInfo,
+  propertyList: any[],
+  name: string,
+}
+
+export interface FBXConnectionDocment extends FBXPropertyTemplate {
+  connections: [number, number, string][],
+
+}
+
+export interface FBXTimeStamp {
+  singleProperty: boolean,
+  Version: number,
+  Year: number,
+  Month: number,
+  Day: number,
+  Hour: number,
+  Minute: number,
+  Second: number,
+  Millisecond: number,
+  propertyList: any[],
+  name: string,
+}
+
+export interface FBXSceneInfo {
+  singleProperty: boolean,
+  Type: string,
+  Version: number,
+  MetaData: FBXMetaData,
+  DocumentUrl: FBXTypedProperty,
+  SrcDocumentUrl: FBXTypedProperty,
+  Original: FBXTypedProperty,
+  LastSaved: FBXTypedProperty,
+  propertyList: string[],
+  name: string,
+  attrName: string,
+  [key: string]: any,
+}
+
+export interface FBXMetaData {
+  singleProperty: boolean,
+  Version: number,
+  Title: string,
+  Subject: string,
+  Author: string,
+  Keywords: string,
+  Revision: string,
+  Comment: string,
+  propertyList: any[],
+  name: string,
+}
+
+export interface FBXTypedProperty {
+  type: string,
+  type2?: string,
+  flag: string,
+  value?: any,
+}
+
+export interface FBXGlobalSettings {
+  singleProperty: boolean,
+  Version: number,
+  UpAxis: FBXTypedProperty,
+  UpAxisSign: FBXTypedProperty,
+  FrontAxis: FBXTypedProperty,
+  FrontAxisSign: FBXTypedProperty,
+  CoordAxis: FBXTypedProperty,
+  CoordAxisSign: FBXTypedProperty,
+  OriginalUpAxis: FBXTypedProperty,
+  OriginalUpAxisSign: FBXTypedProperty,
+  UnitScaleFactor: FBXTypedProperty,
+  OriginalUnitScaleFactor: FBXTypedProperty,
+  AmbientColor: FBXTypedProperty,
+  DefaultCamera: FBXTypedProperty,
+  TimeMode: FBXTypedProperty,
+  TimeProtocol: FBXTypedProperty,
+  SnapOnFrameMode: FBXTypedProperty,
+  TimeSpanStart: FBXTypedProperty,
+  TimeSpanStop: FBXTypedProperty,
+  CustomFrameRate: FBXTypedProperty,
+  TimeMarker: FBXTypedProperty,
+  CurrentTimeMarker: FBXTypedProperty,
+  propertyList: any[],
+  name: string,
+}
+
+export interface FBXDocuments {
+  singleProperty: boolean,
+  Count: number,
+  Document: {
+    [id: string]: FBXDocument,
+  },
+  propertyList: any[],
+  name: string,
+}
+
+export interface FBXDocument {
+  singleProperty: boolean,
+  SourceObject: FBXTypedProperty,
+  ActiveAnimStackName: FBXTypedProperty,
+  propertyList: any[],
+  name: string,
+  RootNode: number,
+  id: number,
+  attrType: string,
+}
+
+export interface FBXDefinitions {
+  singleProperty: boolean,
+  Version: number,
+  Count: number,
+  ObjectType: {
+    [key: string]: FBXObjectType,
+  },
+  propertyList: string[],
+  name: string,
+}
+
+export interface FBXObjectType {
+  singleProperty: boolean,
+  Count: number,
+  PropertyTemplate?: FBXPropertyTemplate,
+  propertyList: string[],
+  name: string,
+  undefined?: FBXObjectType,
+}
+
+export interface FBXPropertyTemplate {
+  singleProperty: boolean,
+  Description: FBXTypedProperty,
+  LocalStart: FBXTypedProperty,
+  LocalStop: FBXTypedProperty,
+  ReferenceStart: FBXTypedProperty,
+  ReferenceStop: FBXTypedProperty,
+  propertyList: string[],
+  name: string,
+}
+export interface FBXRawTargets {
+  geoID?: number,
+  name: string,
+  initialWeight: FBXTreeNodeDetails,
+  id: number,
+  fullWeights: number[],
+}
+export interface FBXMorphTarget {
+  id: string,
+  rawTargets?: FBXRawTargets[],
+  skeleton?: FBXSkeleton,
+}
+export interface UserDataTransform {
+  translation?: number[],
+  rotation?: number[],
+  scale?: number[],
+  preRotation?: number[],
+  postRotation?: number[],
+  rotationOffset?: number[],
+  rotationPivot?: number[],
+  scalingOffset?: number[],
+  scalingPivot?: number[],
+  eulerOrder?: EulerOrder,
+  inheritType?: number,
+  parentMatrix?: Matrix4,
+  parentMatrixWorld?: Matrix4,
+}
+
+export interface FBXSkeleton {
+  ID: string,
+  rawBones: RawBone[],
+  bones: Bone[],
+  geometryID: number,
+}
+
+export interface RawBone {
+  ID: number,
+  indices: number[],
+  weights: number[],
+  transformLink: Matrix4,
+}
+
+export interface FBXPoseNode extends FBXTreeNode {
+  PoseNode: FBXMeshNode | FBXMeshNode[] | Record<string, FBXMeshNode>[],
+  NbPoseNodes: number,
+}
+
+export interface Deformers { skeletons: Record<number, FBXSkeleton>, morphTargets: Record<number, FBXMorphTarget> }
+
+export interface FBXNodeAttribute extends FBXTreeNode {
+  CameraProjectionType?: FBXTreeNode,
+  NearPlane?: FBXTreeNode,
+  FarPlane?: FBXTreeNode,
+  FocalLength?: FBXTreeNode,
+  AspectWidth?: FBXTreeNode,
+  AspectHeight?: FBXTreeNode,
+  FieldOfView?: FBXTreeNode,
+}
+
+export interface FBXAnimationCurveNode extends FBXTreeNode {
+  KeyTime: FBXTreeNodeDetails,
+  KeyValueFloat: FBXTreeNodeDetails,
+}
+
+export interface FBXLightNodeAttribute extends FBXNodeAttribute {
+  CastShadows?: FBXTreeNode,
+  LightType?: FBXTreeNode,
+  Color?: FBXTreeNode,
+  Intensity?: FBXTreeNode,
+  InnerAngle?: FBXTreeNode,
+  OuterAngle?: FBXTreeNode,
+  CastLightOnObject?: FBXTreeNode,
+  EnableFarAttenuation?: FBXTreeNode,
+  FarAttenuationEnd?: FBXTreeNode,
+}
+
+export interface FBXObjects {
+  singleProperty: boolean,
+  Geometry?: {
+    [id: string]: FBXGeometryNode,
+  },
+  Model?: Record<string, FBXModelNode>,
+  Material?: Record<string, FBXMaterialNode>,
+  Pose?: Record<string, FBXPoseNode>,
+  Video?: Record<string, FBXVideoNode>,
+  NodeAttribute?: Record<string, FBXNodeAttribute>,
+  AnimationCurveNode?: Record<string, FBXAnimationCurveNode>,
+  AnimationCurve?: Record<string, FBXAnimationCurveNode>,
+  [key: string]: any,
+  propertyList: any[],
+  name: string,
+}
+
+export interface FBXGeometryNode {
+  Order?: string,
+  Form?: string,
+  KnotVector?: FBXTreeNodeDetails,
+  Points?: FBXTreeNodeDetails,
+  LayerElementColor: any,
+  attrName: string,
+  singleProperty: boolean,
+  Vertices: FBXProperty,
+  Indexes?: FBXProperty,
+  PolygonVertexIndex: FBXProperty,
+  GeometryVersion: number,
+  LayerElementNormal?: {
+    [id: string]: FBXLayerElement,
+  },
+  LayerElementBinormal?: {
+    [id: string]: FBXLayerElement,
+  },
+  LayerElementTangent?: {
+    [id: string]: FBXLayerElement,
+  },
+  LayerElementUV?: {
+    [id: string]: FBXLayerElementUV,
+  },
+  LayerElementSmoothing?: {
+    [id: string]: FBXLayerElement,
+  },
+  LayerElementMaterial?: {
+    [id: string]: FBXMaterialNode,
+  },
+  Layer?: {
+    [id: string]: FBXLayer,
+  },
+  propertyList: any[],
+  id: number,
+  attrType: string,
+  name: string,
+}
+
+export interface FBXLayerElement {
+  singleProperty: boolean,
+  Version: number,
+  Name: string,
+  MappingInformationType: string,
+  ReferenceInformationType: string,
+  Normals?: FBXTreeNodeDetails,
+  NormalsW?: FBXProperty,
+  Binormals?: FBXProperty,
+  BinormalsW?: FBXProperty,
+  Tangents?: FBXProperty,
+  TangentsW?: FBXProperty,
+  Smoothing?: FBXProperty,
+  Materials?: FBXProperty,
+  propertyList: any[],
+  id: number,
+  name: string,
+}
+
+export interface FBXLayerElementUV extends FBXLayerElement {
+  UV: FBXProperty,
+  UVIndex: FBXProperty,
+}
+
+export interface FBXLayerElementColor extends FBXLayerElement {
+  Colors: FBXTreeNodeDetails,
+  ColorIndex: FBXTreeNodeDetails,
+}
+export interface FBXLayerElementNormal extends FBXLayerElement {
+  NormalIndex?: FBXTreeNodeDetails,
+  NormalsIndex?: FBXTreeNodeDetails,
+}
+
+export interface FBXLayer {
+  singleProperty: boolean,
+  Version: number,
+  LayerElement: FBXLayerElementRef,
+  propertyList: any[],
+  id: number,
+  name: string,
+}
+
+export interface FBXLayerElementRef {
+  singleProperty: boolean,
+  Type: string,
+  TypedIndex: number,
+  propertyList: object[],
+  name: string,
+  undefined?: FBXLayerElementRef,
+}
+
+export interface FBXMaterial {
+  singleProperty: boolean,
+  Version: number,
+  ShadingModel: string,
+  MultiLayer: number,
+  AmbientColor: FBXTypedProperty,
+  DiffuseColor: FBXTypedProperty,
+  DiffuseFactor: FBXTypedProperty,
+  TransparencyFactor: FBXTypedProperty,
+  Emissive: FBXTypedProperty,
+  Ambient: FBXTypedProperty,
+  Diffuse: FBXTypedProperty,
+  Opacity: FBXTypedProperty,
+  propertyList: object[],
+  name: string,
+  id: number,
+  attrName: string,
+}
+
+export interface FBXTransformData {
+  postRotation?: number[],
+  scalingOffset?: number[],
+  scalingPivot?: number[],
+  rotationOffset?: number[],
+  rotationPivot?: number[],
+  parentMatrixWorld?: Matrix4,
+  parentMatrix?: Matrix4,
+  eulerOrder?: string,
+  inheritType?: number,
+  translation?: number[],
+  rotation?: number[],
+  scale?: number[],
+  preRotation?: number[],
+}
+
+export interface FBXConnectionNode {
+  parents: FBXConnectionReference[],
+  children: FBXConnectionReference[],
+}
+
+export interface FBXTreeNode {
+  value?: FBXEulerOrder | string | number,
+  ID?: number,
+  id: number,
+  attrName: string,
+  attrType: string,
+  name: string,
+  propertyList?: string[],
+  singleProperty?: boolean,
+  version?: number,
+}
+
+export interface FBXConnectionReference {
+  ID: number,
+  relationship?: number | string, // 可能是OO或OP等关系类型
+}
+
+export interface FBXTreeNodeDetails extends FBXTreeNode {
+  a: number[],
+}
+
+export interface FBXMeshNode extends FBXTreeNode {
+  DeformPercent: FBXTreeNodeDetails,
+  FullWeights: FBXTreeNodeDetails,
+  Indexes?: FBXTreeNodeDetails,
+  Transform?: FBXTreeNodeDetails,
+  TransformLink?: FBXTreeNodeDetails,
+  UserData?: FBXTreeNodeDetails,
+  Weights?: FBXTreeNodeDetails,
+  Material?: FBXTreeNodeDetails,
+  Matrix?: FBXTreeNodeDetails,
+  Node?: number,
+}
+
+export interface FBXModelNode extends FBXTreeNode {
+  LookAtProperty?: string,
+  GeometricTranslation: FBXTypedProperty,
+  GeometricRotation: FBXTypedProperty,
+  GeometricScaling: FBXTypedProperty,
+  singleProperty: boolean,
+  ScalingOffset: FBXTypedProperty,
+  RotationOffset: FBXTypedProperty,
+  Lcl_Rotation: FBXTypedProperty,
+  PostRotation: FBXTypedProperty,
+  Version: number,
+  RotationPivot: FBXTypedProperty,
+  ScalingPivot: FBXTypedProperty,
+  RotationActive: FBXTypedProperty,
+  InheritType: FBXTypedProperty,
+  ScalingMax: FBXTypedProperty,
+  DefaultAttributeIndex: FBXTypedProperty,
+  currentUVSet: FBXTypedProperty,
+  RotationOrder: FBXTreeNode,
+  Shading: boolean,
+  Lcl_Translation: FBXTypedProperty,
+  Lcl_Scaling: FBXTypedProperty,
+  filmboxTypeID: FBXTypedProperty,
+  lockInfluenceWeights: FBXTypedProperty,
+  PreRotation: FBXTypedProperty,
+  Culling: string,
+}
+
+/**
+ * FBX文件中纹理节点的接口定义
+ */
+export interface FBXTextureNode {
+  WrapModeU: {
+    value: number,
+  },
+  Scaling: FBXTypedProperty,
+  WrapModeV: {
+    value: number,
+  }, // Added back the WrapModeV property
+  Translation: FBXTypedProperty,
+  /** 纹理文件的完整路径 */
+  FileName: string,
+
+  /** 媒体文件名 */
+  Media: string,
+
+  /** 相对路径的文件名 */
+  RelativeFilename: string,
+
+  /** 纹理名称，通常描述纹理用途 */
+  TextureName: string,
+
+  /** 纹理类型 */
+  Type: string,
+
+  /** 使用材质的标志 */
+  UseMaterial: {
+    type: string,
+    type2: string,
+    flag: string,
+    value: number,
+  },
+
+  /** 版本号 */
+  Version: number,
+
+  /** 属性名称 */
+  attrName: string,
+
+  /** 属性类型 */
+  attrType: string,
+
+  /** 唯一标识符 */
+  id: number,
+
+  /** 节点名称 */
+  name: string,
+
+  /** 属性列表，通常包含 [id, 名称, 类型] */
+  propertyList: Array<number | string>,
+
+  /** 是否为单一属性 */
+  singleProperty: boolean,
+}
+
+export interface FBXVideoNode {
+// 主要属性
+  Content: ArrayBuffer,
+  Filename: string,
+  RelativeFilename: string,
+  Path: string,
+
+  // 类型标识
+  Type: string,
+  type: string,
+  type2: string,
+  attrType: string,
+
+  // 标志和值
+  flag: string,
+  value: string,
+  UseMipMap: number,
+
+  // 标识信息
+  id: number,
+  name: string,
+  attrName: string,
+
+  // 属性列表，通常包含 [id, 文件名, 类型]
+  propertyList: Array<string | number>,
+
+  // 是否为单一属性
+  singleProperty: boolean,
+}
+
+export interface FBXConnectionDocment {
+  from: number,
+  to: number,
+  relationship?: number,
+}
+
+// FBX连接类型
+export enum FBXConnectionType {
+  OBJECT_OBJECT = 'OO', // 对象到对象的连接
+  OBJECT_PROPERTY = 'OP' // 对象到属性的连接
+}
+
+/**
+ * FBX材质节点中颜色或数值属性的通用接口
+ */
+export interface IFBXPropertyValue<T> {
+  /** 属性类型 */
+  type: string,
+  /** 次级类型 */
+  type2: string,
+  /** 标志 */
+  flag: string,
+  /** 属性值 */
+  value: T,
+}
+
+/**
+ * FBX文件中材质节点的接口定义
+ */
+export interface FBXMaterialNode {
+  MappingInformationType: string,
+  ReferenceInformationType: string,
+  Materials: any,
+  Diffuse: IFBXPropertyValue<number[]>,
+  DisplacementFactor: IFBXPropertyValue<number[] | number>,
+  Emissive: IFBXPropertyValue<number[]>,
+  TransparencyFactor: IFBXPropertyValue<string>,
+  Opacity: IFBXPropertyValue<string>,
+  TransparentColor: IFBXPropertyValue<string[]>,
+  Specular: IFBXPropertyValue<number[]>,
+  /** 唯一标识符 */
+  id: number,
+
+  /** 属性名称 */
+  attrName: string,
+
+  /** 属性类型 */
+  attrType: string,
+
+  /** 是否为单一属性 */
+  singleProperty: boolean,
+
+  /** 节点名称 */
+  name: string,
+
+  /** 版本号 */
+  Version: number,
+
+  /** 着色模型类型 */
+  ShadingModel: IFBXPropertyValue<string>,
+
+  /** 是否多层 */
+  MultiLayer: number,
+
+  /** 漫反射颜色 */
+  DiffuseColor: IFBXPropertyValue<number[]>,
+
+  /** 自发光颜色 */
+  EmissiveColor: IFBXPropertyValue<number[]>,
+
+  /** 自发光因子 */
+  EmissiveFactor: IFBXPropertyValue<string>,
+
+  /** 环境光颜色 */
+  AmbientColor: IFBXPropertyValue<number[]>,
+
+  /** 环境光因子 */
+  AmbientFactor: IFBXPropertyValue<number>,
+
+  /** 凹凸因子 */
+  BumpFactor: IFBXPropertyValue<number>,
+
+  /** 镜面颜色 */
+  SpecularColor: IFBXPropertyValue<number[]>,
+
+  /** 镜面因子 */
+  SpecularFactor: IFBXPropertyValue<number>,
+
+  /** 光泽度 */
+  Shininess: IFBXPropertyValue<number>,
+
+  /** 光泽度指数 */
+  ShininessExponent: IFBXPropertyValue<number>,
+
+  /** 反射颜色 */
+  ReflectionColor: IFBXPropertyValue<number[]>,
+
+  /** 反射因子 */
+  ReflectionFactor: IFBXPropertyValue<number>,
+
+  /** 属性列表，通常包含 [id, 名称, 类型] */
+  propertyList: Array<number | string>,
+}
+
+export enum FBXEulerOrder {
+  'ZYX' = 0, // -> XYZ extrinsic
+  'YZX' = 1, // -> XZY extrinsic
+  'XZY' = 2, // -> YZX extrinsic
+  'ZXY' = 3, // -> YXZ extrinsic
+  'YXZ' = 4, // -> ZXY extrinsic
+  'XYZ' = 5, // -> ZYX extrinsic
+  'SphericXYZ' = 6, // not possible to support
+}
+
+// FBX节点类型枚举
+export enum FBXNodeType {
+  MODEL = 'Model',
+  GEOMETRY = 'Geometry',
+  MATERIAL = 'Material',
+  TEXTURE = 'Texture',
+  VIDEO = 'Video',
+  ANIMATION = 'Animation',
+  DEFORMER = 'Deformer'
+}
+
+// FBX材质属性类型
+export enum FBXMaterialPropertyType {
+  EMISSIVE = 'Emissive',
+  AMBIENT = 'Ambient',
+  DIFFUSE = 'Diffuse',
+  SPECULAR = 'Specular',
+  SHININESS = 'Shininess',
+  REFLECTIVITY = 'Reflectivity'
+}
+
+// FBX映射信息类型
+export enum MappingInformationType {
+  BY_POLYGON_VERTEX = 'ByPolygonVertex',
+  BY_POLYGON = 'ByPolygon',
+  BY_VERTEX = 'ByVertex',
+  BY_EDGE = 'ByEdge',
+  ALL_SAME = 'AllSame'
+}
+
+// FBX引用信息类型
+export enum ReferenceInformationType {
+  DIRECT = 'Direct',
+  INDEX_TO_DIRECT = 'IndexToDirect'
+}
+
+// FBX层元素类型
+export enum LayerElementType {
+  NORMAL = 'LayerElementNormal',
+  BINORMAL = 'LayerElementBinormal',
+  TANGENT = 'LayerElementTangent',
+  UV = 'LayerElementUV',
+  COLOR = 'LayerElementColor',
+  MATERIAL = 'LayerElementMaterial',
+  SMOOTHING = 'LayerElementSmoothing'
+}
+
+export interface Global {
+  fbxTree: IFBXTree,
+  connections: Map<number, FBXConnectionNode>,
+  sceneGraph: Group,
+}
+
+export const global: Global = {
+  fbxTree: {},
+  connections: new Map(),
+  sceneGraph: new Group(),
+};

--- a/src/curves/NURBS-curve.ts
+++ b/src/curves/NURBS-curve.ts
@@ -1,0 +1,175 @@
+import type {
+  CurveJSON,
+  Vector2 } from 'three';
+import {
+  Curve,
+  Vector3,
+  Vector4,
+} from 'three';
+import * as NURBSUtils from './NURBS-utils.js';
+
+/**
+ * 曲线的 JSON 数据格式
+ * @see {@link NURBSCurveJSON}
+ */
+interface NURBSCurveJSON extends CurveJSON {
+  degree: number,
+  knots: number[],
+  controlPoints: number[][],
+  startKnot: number,
+  endKnot: number,
+}
+
+/**
+ * This class represents a NURBS curve.
+ *
+ * Implementation is based on `(x, y [, z=0 [, w=1]])` control points with `w=weight`.
+ *
+ * @augments Curve
+ * @three_import import { NURBSCurve } from 'three/addons/curves/NURBSCurve.js';
+ */
+export class NURBSCurve extends Curve<Vector3> {
+  degree: number;
+  knots: number[];
+  controlPoints: (Vector2 | Vector3 | Vector4)[];
+  startKnot: number;
+  endKnot: number;
+
+  /**
+	 * Constructs a new NURBS curve.
+	 *
+	 * @param {number} degree - The NURBS degree.
+	 * @param {Array<number>} knots - The knots as a flat array of numbers.
+	 * @param {Array<Vector2|Vector3|Vector4>} controlPoints - An array holding control points.
+	 * @param {number} [startKnot] - Index of the start knot into the `knots` array.
+	 * @param {number} [endKnot] - Index of the end knot into the `knots` array.
+	 */
+  constructor (degree: number, knots: number[], controlPoints: (Vector2 | Vector3 | Vector4)[], startKnot?: number, endKnot?: number) {
+
+    super();
+
+    const knotsLength = knots ? knots.length - 1 : 0;
+    const pointsLength = controlPoints ? controlPoints.length : 0;
+
+    /**
+		 * The NURBS degree.
+		 *
+		 * @type {number}
+		 */
+    this.degree = degree;
+
+    /**
+		 * The knots as a flat array of numbers.
+		 *
+		 * @type {Array<number>}
+		 */
+    this.knots = knots;
+
+    /**
+		 * An array of control points.
+		 *
+		 * @type {Array<Vector4>}
+		 */
+    this.controlPoints = [];
+
+    /**
+		 * Index of the start knot into the `knots` array.
+		 *
+		 * @type {number}
+		 */
+    this.startKnot = startKnot || 0;
+
+    /**
+		 * Index of the end knot into the `knots` array.
+		 *
+		 * @type {number}
+		 */
+    this.endKnot = endKnot || knotsLength;
+
+    for (let i = 0; i < pointsLength; ++ i) {
+
+      // ensure Vector4 for control points
+      const point = controlPoints[ i ] as Vector4;
+
+      this.controlPoints[ i ] = new Vector4(point.x, point.y, point.z, point.w);
+
+    }
+
+  }
+
+  /**
+	 * This method returns a vector in 3D space for the given interpolation factor.
+	 *
+	 * @param {number} t - A interpolation factor representing a position on the curve. Must be in the range `[0,1]`.
+	 * @param {Vector3} [optionalTarget] - The optional target vector the result is written to.
+	 * @return {Vector3} The position on the curve.
+	 */
+  override getPoint (t: number, optionalTarget = new Vector3()) {
+
+    const point = optionalTarget;
+
+    const u = this.knots[ this.startKnot ] + t * (this.knots[ this.endKnot ] - this.knots[ this.startKnot ]); // linear mapping t->u
+
+    // following results in (wx, wy, wz, w) homogeneous point
+    const hpoint = NURBSUtils.calcBSplinePoint(this.degree, this.knots, this.controlPoints as Vector4[], u);
+
+    if (hpoint.w !== 1.0) {
+
+      // project to 3D space: (wx, wy, wz, w) -> (x, y, z, 1)
+      hpoint.divideScalar(hpoint.w);
+
+    }
+
+    return point.set(hpoint.x, hpoint.y, hpoint.z);
+
+  }
+
+  /**
+	 * Returns a unit vector tangent for the given interpolation factor.
+	 *
+	 * @param {number} t - The interpolation factor.
+	 * @param {Vector3} [optionalTarget] - The optional target vector the result is written to.
+	 * @return {Vector3} The tangent vector.
+	 */
+  override getTangent (t: number, optionalTarget = new Vector3()) {
+
+    const tangent = optionalTarget;
+
+    const u = this.knots[ 0 ] + t * (this.knots[ this.knots.length - 1 ] - this.knots[ 0 ]);
+    const ders = NURBSUtils.calcNURBSDerivatives(this.degree, this.knots, this.controlPoints as Vector4[], u, 1);
+
+    tangent.copy(ders[ 1 ]).normalize();
+
+    return tangent;
+
+  }
+
+  override toJSON () {
+
+    const data = super.toJSON() as NURBSCurveJSON;
+
+    data.degree = this.degree;
+    data.knots = [...this.knots];
+    data.controlPoints = this.controlPoints.map(p => p.toArray());
+    data.startKnot = this.startKnot;
+    data.endKnot = this.endKnot;
+
+    return data;
+
+  }
+
+  override fromJSON (json: NURBSCurveJSON) {
+
+    super.fromJSON(json);
+
+    this.degree = json.degree;
+    this.knots = [...json.knots];
+    this.controlPoints = json.controlPoints.map(p => new Vector4(p[ 0 ], p[ 1 ], p[ 2 ], p[ 3 ]));
+    this.startKnot = json.startKnot;
+    this.endKnot = json.endKnot;
+
+    return this;
+
+  }
+
+}

--- a/src/curves/NURBS-utils.ts
+++ b/src/curves/NURBS-utils.ts
@@ -1,0 +1,543 @@
+import {
+  Vector3,
+  Vector4,
+} from 'three';
+
+/**
+ * @module NURBSUtils
+ * @three_import import * as NURBSUtils from 'three/addons/curves/NURBSUtils.js';
+ */
+
+/**
+ * Finds knot vector span.
+ *
+ * @param {number} p - The degree.
+ * @param {number} u - The parametric value.
+ * @param {Array<number>} U - The knot vector.
+ * @return {number} The span.
+ */
+function findSpan (p: number, u: number, U: Array<number>): number {
+
+  const n = U.length - p - 1;
+
+  if (u >= U[ n ]) {
+
+    return n - 1;
+
+  }
+
+  if (u <= U[ p ]) {
+
+    return p;
+
+  }
+
+  let low = p;
+  let high = n;
+  let mid = Math.floor((low + high) / 2);
+
+  while (u < U[ mid ] || u >= U[ mid + 1 ]) {
+
+    if (u < U[ mid ]) {
+
+      high = mid;
+
+    } else {
+
+      low = mid;
+
+    }
+
+    mid = Math.floor((low + high) / 2);
+
+  }
+
+  return mid;
+
+}
+
+/**
+ * Calculates basis functions. See The NURBS Book, page 70, algorithm A2.2.
+ *
+ * @param {number} span - The span in which `u` lies.
+ * @param {number} u - The parametric value.
+ * @param {number} p - The degree.
+ * @param {Array<number>} U - The knot vector.
+ * @return {Array<number>} Array[p+1] with basis functions values.
+ */
+function calcBasisFunctions (span: number, u: number, p: number, U: Array<number>): Array<number> {
+
+  const N: Array<number> = [];
+  const left: Array<number> = [];
+  const right: Array<number> = [];
+
+  N[ 0 ] = 1.0;
+
+  for (let j = 1; j <= p; ++ j) {
+
+    left[ j ] = u - U[ span + 1 - j ];
+    right[ j ] = U[ span + j ] - u;
+
+    let saved = 0.0;
+
+    for (let r = 0; r < j; ++ r) {
+
+      const rv = right[ r + 1 ];
+      const lv = left[ j - r ];
+      const temp = N[ r ] / (rv + lv);
+
+      N[ r ] = saved + rv * temp;
+      saved = lv * temp;
+
+    }
+
+    N[ j ] = saved;
+
+  }
+
+  return N;
+
+}
+
+/**
+ * Calculates B-Spline curve points. See The NURBS Book, page 82, algorithm A3.1.
+ *
+ * @param {number} p - The degree of the B-Spline.
+ * @param {Array<number>} U - The knot vector.
+ * @param {Array<Vector4>} P - The control points
+ * @param {number} u - The parametric point.
+ * @return {Vector4} The point for given `u`.
+ */
+function calcBSplinePoint (p: number, U: Array<number>, P: Array<Vector4>, u: number): Vector4 {
+
+  const span = findSpan(p, u, U);
+  const N = calcBasisFunctions(span, u, p, U);
+  const C = new Vector4(0, 0, 0, 0);
+
+  for (let j = 0; j <= p; ++ j) {
+
+    const point = P[ span - p + j ];
+    const Nj = N[ j ];
+    const wNj = point.w * Nj;
+
+    C.x += point.x * wNj;
+    C.y += point.y * wNj;
+    C.z += point.z * wNj;
+    C.w += point.w * Nj;
+
+  }
+
+  return C;
+
+}
+
+/**
+ * Calculates basis functions derivatives. See The NURBS Book, page 72, algorithm A2.3.
+ *
+ * @param {number} span - The span in which `u` lies.
+ * @param {number} u - The parametric point.
+ * @param {number} p - The degree.
+ * @param {number} n - number of derivatives to calculate
+ * @param {Array<number>} U - The knot vector.
+ * @return {Array<Array<number>>} An array[n+1][p+1] with basis functions derivatives.
+ */
+function calcBasisFunctionDerivatives (span: number, u: number, p: number, n: number, U: Array<number>): Array<Array<number>> {
+
+  const zeroArr: Array<number> = [];
+
+  for (let i = 0; i <= p; ++ i) {zeroArr[ i ] = 0.0;}
+
+  const ders = [];
+
+  for (let i = 0; i <= n; ++ i) {ders[ i ] = zeroArr.slice(0);}
+
+  const ndu = [];
+
+  for (let i = 0; i <= p; ++ i) {ndu[ i ] = zeroArr.slice(0);}
+
+  ndu[ 0 ][ 0 ] = 1.0;
+
+  const left = zeroArr.slice(0);
+  const right = zeroArr.slice(0);
+
+  for (let j = 1; j <= p; ++ j) {
+
+    left[ j ] = u - U[ span + 1 - j ];
+    right[ j ] = U[ span + j ] - u;
+
+    let saved = 0.0;
+
+    for (let r = 0; r < j; ++ r) {
+
+      const rv = right[ r + 1 ];
+      const lv = left[ j - r ];
+
+      ndu[ j ][ r ] = rv + lv;
+
+      const temp = ndu[ r ][ j - 1 ] / ndu[ j ][ r ];
+
+      ndu[ r ][ j ] = saved + rv * temp;
+      saved = lv * temp;
+
+    }
+
+    ndu[ j ][ j ] = saved;
+
+  }
+
+  for (let j = 0; j <= p; ++ j) {
+
+    ders[ 0 ][ j ] = ndu[ j ][ p ];
+
+  }
+
+  for (let r = 0; r <= p; ++ r) {
+
+    let s1 = 0;
+    let s2 = 1;
+
+    const a = [];
+
+    for (let i = 0; i <= p; ++ i) {
+
+      a[ i ] = zeroArr.slice(0);
+
+    }
+
+    a[ 0 ][ 0 ] = 1.0;
+
+    for (let k = 1; k <= n; ++ k) {
+
+      let d = 0.0;
+      const rk = r - k;
+      const pk = p - k;
+
+      if (r >= k) {
+
+        a[ s2 ][ 0 ] = a[ s1 ][ 0 ] / ndu[ pk + 1 ][ rk ];
+        d = a[ s2 ][ 0 ] * ndu[ rk ][ pk ];
+
+      }
+
+      const j1 = (rk >= - 1) ? 1 : - rk;
+      const j2 = (r - 1 <= pk) ? k - 1 : p - r;
+
+      for (let j = j1; j <= j2; ++ j) {
+
+        a[ s2 ][ j ] = (a[ s1 ][ j ] - a[ s1 ][ j - 1 ]) / ndu[ pk + 1 ][ rk + j ];
+        d += a[ s2 ][ j ] * ndu[ rk + j ][ pk ];
+
+      }
+
+      if (r <= pk) {
+
+        a[ s2 ][ k ] = - a[ s1 ][ k - 1 ] / ndu[ pk + 1 ][ r ];
+        d += a[ s2 ][ k ] * ndu[ r ][ pk ];
+
+      }
+
+      ders[ k ][ r ] = d;
+
+      const j = s1;
+
+      s1 = s2;
+      s2 = j;
+
+    }
+
+  }
+
+  let r = p;
+
+  for (let k = 1; k <= n; ++ k) {
+
+    for (let j = 0; j <= p; ++ j) {
+
+      ders[ k ][ j ] *= r;
+
+    }
+
+    r *= p - k;
+
+  }
+
+  return ders;
+
+}
+
+/**
+ * Calculates derivatives of a B-Spline. See The NURBS Book, page 93, algorithm A3.2.
+ *
+ * @param {number} p - The degree.
+ * @param {Array<number>} U - The knot vector.
+ * @param {Array<Vector4>} P - The control points
+ * @param {number} u - The parametric point.
+ * @param {number} nd - The number of derivatives.
+ * @return {Array<Vector4>} An array[d+1] with derivatives.
+ */
+function calcBSplineDerivatives (p: number, U: number[], P: Vector4[], u: number, nd: number): Array<Vector4> {
+
+  const du = nd < p ? nd : p;
+  const CK = [];
+  const span = findSpan(p, u, U);
+  const nders = calcBasisFunctionDerivatives(span, u, p, du, U);
+  const Pw = [];
+
+  for (let i = 0; i < P.length; ++ i) {
+
+    const point = P[ i ].clone();
+    const w = point.w;
+
+    point.x *= w;
+    point.y *= w;
+    point.z *= w;
+
+    Pw[ i ] = point;
+
+  }
+
+  for (let k = 0; k <= du; ++ k) {
+
+    const point = Pw[ span - p ].clone().multiplyScalar(nders[ k ][ 0 ]);
+
+    for (let j = 1; j <= p; ++ j) {
+
+      point.add(Pw[ span - p + j ].clone().multiplyScalar(nders[ k ][ j ]));
+
+    }
+
+    CK[ k ] = point;
+
+  }
+
+  for (let k = du + 1; k <= nd + 1; ++ k) {
+
+    CK[ k ] = new Vector4(0, 0, 0);
+
+  }
+
+  return CK;
+
+}
+
+/**
+ * Calculates "K over I".
+ *
+ * @param {number} k - The K value.
+ * @param {number} i - The I value.
+ * @return {number} k!/(i!(k-i)!)
+ */
+function calcKoverI (k: number, i: number): number {
+
+  let nom = 1;
+
+  for (let j = 2; j <= k; ++ j) {
+
+    nom *= j;
+
+  }
+
+  let denom = 1;
+
+  for (let j = 2; j <= i; ++ j) {
+
+    denom *= j;
+
+  }
+
+  for (let j = 2; j <= k - i; ++ j) {
+
+    denom *= j;
+
+  }
+
+  return nom / denom;
+
+}
+
+/**
+ * Calculates derivatives (0-nd) of rational curve. See The NURBS Book, page 127, algorithm A4.2.
+ *
+ * @param {Array<Vector4>} Pders - Array with derivatives.
+ * @return {Array<Vector3>} An array with derivatives for rational curve.
+ */
+function calcRationalCurveDerivatives (Pders: Array<Vector4>): Array<Vector3> {
+
+  const nd = Pders.length;
+  const Aders = [];
+  const wders = [];
+
+  for (let i = 0; i < nd; ++ i) {
+
+    const point = Pders[ i ];
+
+    Aders[ i ] = new Vector3(point.x, point.y, point.z);
+    wders[ i ] = point.w;
+
+  }
+
+  const CK = [];
+
+  for (let k = 0; k < nd; ++ k) {
+
+    const v = Aders[ k ].clone();
+
+    for (let i = 1; i <= k; ++ i) {
+
+      v.sub(CK[ k - i ].clone().multiplyScalar(calcKoverI(k, i) * wders[ i ]));
+
+    }
+
+    CK[ k ] = v.divideScalar(wders[ 0 ]);
+
+  }
+
+  return CK;
+
+}
+
+/**
+ * Calculates NURBS curve derivatives. See The NURBS Book, page 127, algorithm A4.2.
+ *
+ * @param {number} p - The degree.
+ * @param {Array<number>} U - The knot vector.
+ * @param {Array<Vector4>} P - The control points in homogeneous space.
+ * @param {number} u - The parametric point.
+ * @param {number} nd - The number of derivatives.
+ * @return {Array<Vector3>} array with derivatives for rational curve.
+ */
+function calcNURBSDerivatives (p: number, U: number[], P: Vector4[], u: number, nd: number): Array<Vector3> {
+
+  const Pders = calcBSplineDerivatives(p, U, P, u, nd);
+
+  return calcRationalCurveDerivatives(Pders);
+
+}
+
+/**
+ * Calculates a rational B-Spline surface point. See The NURBS Book, page 134, algorithm A4.3.
+ *
+ * @param {number} p - The first degree of B-Spline surface.
+ * @param {number} q - The second degree of B-Spline surface.
+ * @param {Array<number>} U - The first knot vector.
+ * @param {Array<number>} V - The second knot vector.
+ * @param {Array<Array<Vector4>>} P - The control points in homogeneous space.
+ * @param {number} u - The first parametric point.
+ * @param {number} v - The second parametric point.
+ * @param {Vector3} target - The target vector.
+ */
+function calcSurfacePoint (p: number, q: number, U: number[], V: number[], P: Array<Array<Vector4>>, u: number, v: number, target: Vector3) {
+
+  const uspan = findSpan(p, u, U);
+  const vspan = findSpan(q, v, V);
+  const Nu = calcBasisFunctions(uspan, u, p, U);
+  const Nv = calcBasisFunctions(vspan, v, q, V);
+  const temp = [];
+
+  for (let l = 0; l <= q; ++ l) {
+
+    temp[ l ] = new Vector4(0, 0, 0, 0);
+    for (let k = 0; k <= p; ++ k) {
+
+      const point = P[ uspan - p + k ][ vspan - q + l ].clone();
+      const w = point.w;
+
+      point.x *= w;
+      point.y *= w;
+      point.z *= w;
+      temp[ l ].add(point.multiplyScalar(Nu[ k ]));
+
+    }
+
+  }
+
+  const Sw = new Vector4(0, 0, 0, 0);
+
+  for (let l = 0; l <= q; ++ l) {
+
+    Sw.add(temp[ l ].multiplyScalar(Nv[ l ]));
+
+  }
+
+  Sw.divideScalar(Sw.w);
+  target.set(Sw.x, Sw.y, Sw.z);
+
+}
+
+/**
+ * Calculates a rational B-Spline volume point. See The NURBS Book, page 134, algorithm A4.3.
+ *
+ * @param {number} p - The first degree of B-Spline surface.
+ * @param {number} q - The second degree of B-Spline surface.
+ * @param {number} r - The third degree of B-Spline surface.
+ * @param {Array<number>} U - The first knot vector.
+ * @param {Array<number>} V - The second knot vector.
+ * @param {Array<number>} W - The third knot vector.
+ * @param {Array<Array<Array<Vector4>>>} P - The control points in homogeneous space.
+ * @param {number} u - The first parametric point.
+ * @param {number} v - The second parametric point.
+ * @param {number} w - The third parametric point.
+ * @param {Vector3} target - The target vector.
+ */
+function calcVolumePoint (p: number, q: number, r: number, U: number[], V: number[], W: number[], P: Array<Array<Array<Vector4>>>, u: number, v: number, w: number, target: Vector3) {
+
+  const uspan = findSpan(p, u, U);
+  const vspan = findSpan(q, v, V);
+  const wspan = findSpan(r, w, W);
+  const Nu = calcBasisFunctions(uspan, u, p, U);
+  const Nv = calcBasisFunctions(vspan, v, q, V);
+  const Nw = calcBasisFunctions(wspan, w, r, W);
+  const temp: Array<Array<Vector4>> = [];
+
+  for (let m = 0; m <= r; ++ m) {
+
+    temp[ m ] = [];
+
+    for (let l = 0; l <= q; ++ l) {
+
+      temp[ m ][ l ] = new Vector4(0, 0, 0, 0);
+      for (let k = 0; k <= p; ++ k) {
+
+        const point = P[ uspan - p + k ][ vspan - q + l ][ wspan - r + m ].clone();
+        const w = point.w;
+
+        point.x *= w;
+        point.y *= w;
+        point.z *= w;
+        temp[ m ][ l ].add(point.multiplyScalar(Nu[ k ]));
+
+      }
+
+    }
+
+  }
+
+  const Sw = new Vector4(0, 0, 0, 0);
+
+  for (let m = 0; m <= r; ++ m) {
+
+    for (let l = 0; l <= q; ++ l) {
+
+      Sw.add(temp[ m ][ l ].multiplyScalar(Nw[ m ]).multiplyScalar(Nv[ l ]));
+
+    }
+
+  }
+
+  Sw.divideScalar(Sw.w);
+  target.set(Sw.x, Sw.y, Sw.z);
+
+}
+
+export {
+  findSpan,
+  calcBasisFunctions,
+  calcBSplinePoint,
+  calcBasisFunctionDerivatives,
+  calcBSplineDerivatives,
+  calcKoverI,
+  calcRationalCurveDerivatives,
+  calcNURBSDerivatives,
+  calcSurfacePoint,
+  calcVolumePoint,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * from './FBX-loader';

--- a/src/parse/FBX-animation-parser.ts
+++ b/src/parse/FBX-animation-parser.ts
@@ -1,0 +1,832 @@
+import type { EulerOrder } from 'three';
+import { PropertyBinding, Matrix4, AnimationClip, Vector3, Quaternion, VectorKeyframeTrack, MathUtils, Euler, QuaternionKeyframeTrack, NumberKeyframeTrack } from 'three';
+import { convertFBXTimeToSeconds, getEulerOrder } from './utils';
+import { global } from '../constants';
+
+interface AnimationCurve {
+  id: number,
+  times: number[],
+  values: number[],
+}
+
+interface AnimationNode {
+  morphName?: string,
+  DeformPercent?: CurveNode,
+  S?: CurveNode,
+  R?: CurveNode,
+  T?: CurveNode,
+  transform?: Matrix4,
+  modelName: string,
+  ID: number,
+  eulerOrder?: EulerOrder,
+  preRotation?: [number, number, number],
+  postRotation?: [number, number, number],
+  initialPosition: number[],
+  initialRotation: number[],
+  initialScale: number[],
+}
+
+interface CurveNode {
+  id: number,
+  attr: string,
+  curves: {
+    x?: AnimationCurve,
+    y?: AnimationCurve,
+    z?: AnimationCurve,
+    morph?: AnimationCurve,
+  },
+}
+
+interface RawClip {
+  name: string,
+  layer: AnimationNode[],
+}
+
+// parse animation data from FBXTree
+export class AnimationParser {
+
+  // take raw animation clips and turn them into three.js animation clips
+  parse () {
+
+    const animationClips = [];
+
+    const rawClips = this.parseClips();
+
+    if (rawClips !== undefined) {
+
+      for (const key in rawClips) {
+
+        const rawClip = rawClips[ key ];
+
+        const clip = this.addClip(rawClip);
+
+        animationClips.push(clip);
+
+      }
+
+    }
+
+    return animationClips;
+
+  }
+
+  parseClips (): Record<string, RawClip> | undefined {
+    const objects = global.fbxTree.Objects;
+
+    if (!objects) {
+      throw new Error('FBXTree.Objects is undefined');
+    }
+    // since the actual transformation data is stored in FBXTree.Objects.AnimationCurve,
+    // if this is undefined we can safely assume there are no animations
+    if (objects.AnimationCurve === undefined) {return undefined;}
+
+    const curveNodesMap = this.parseAnimationCurveNodes();
+
+    this.parseAnimationCurves(curveNodesMap);
+
+    const layersMap = this.parseAnimationLayers(curveNodesMap);
+    const rawClips = this.parseAnimStacks(layersMap);
+
+    return rawClips;
+
+  }
+
+  // parse nodes in FBXTree.Objects.AnimationCurveNode
+  // each AnimationCurveNode holds data for an animation transform for a model (e.g. left arm rotation )
+  // and is referenced by an AnimationLayer
+  parseAnimationCurveNodes (): Map<number, CurveNode> {
+    const objects = global.fbxTree.Objects;
+
+    if (!objects) {
+      throw new Error('FBXTree.Objects is undefined');
+    }
+    const rawCurveNodes = objects.AnimationCurveNode;
+
+    const curveNodesMap: Map<number, CurveNode> = new Map();
+
+    for (const nodeID in rawCurveNodes) {
+
+      const rawCurveNode = rawCurveNodes[ nodeID ];
+
+      if (rawCurveNode.attrName.match(/S|R|T|DeformPercent/) !== null) {
+
+        const curveNode: CurveNode = {
+
+          id: rawCurveNode.id,
+          attr: rawCurveNode.attrName,
+          curves: {},
+
+        };
+
+        curveNodesMap.set(curveNode.id, curveNode);
+
+      }
+
+    }
+
+    return curveNodesMap;
+
+  }
+
+  // parse nodes in FBXTree.Objects.AnimationCurve and connect them up to
+  // previously parsed AnimationCurveNodes. Each AnimationCurve holds data for a single animated
+  // axis ( e.g. times and values of x rotation)
+  parseAnimationCurves (curveNodesMap: Map<number, CurveNode>) {
+    const objects = global.fbxTree.Objects;
+
+    if (!objects) {
+      throw new Error('FBXTree.Objects is undefined');
+    }
+    const rawCurves = objects.AnimationCurve;
+
+    // TODO: Many values are identical up to roundoff error, but won't be optimised
+    // e.g. position times: [0, 0.4, 0. 8]
+    // position values: [7.23538335023477e-7, 93.67518615722656, -0.9982695579528809, 7.23538335023477e-7, 93.67518615722656, -0.9982695579528809, 7.235384487103147e-7, 93.67520904541016, -0.9982695579528809]
+    // clearly, this should be optimised to
+    // times: [0], positions [7.23538335023477e-7, 93.67518615722656, -0.9982695579528809]
+    // this shows up in nearly every FBX file, and generally time array is length > 100
+
+    for (const nodeID in rawCurves) {
+
+      const animationCurve: AnimationCurve = {
+
+        id: rawCurves[ nodeID ].id,
+        times: rawCurves[ nodeID ].KeyTime.a.map(convertFBXTimeToSeconds),
+        values: rawCurves[ nodeID ].KeyValueFloat.a,
+
+      };
+
+      const relationships = global.connections.get(animationCurve.id);
+
+      if (relationships !== undefined) {
+        const parent = relationships.parents[0];
+
+        if (parent && typeof parent.ID !== 'undefined') {
+          const animationCurveID = parent.ID;
+          const animationCurveRelationship = parent.relationship;
+
+          // 检查 relationship 是否是字符串
+          if (typeof animationCurveRelationship === 'string') {
+            // 检查 curveNodesMap 中是否存在该 ID
+            const curveNode = curveNodesMap.get(animationCurveID);
+
+            if (curveNode) {
+              if (animationCurveRelationship.match(/X/)) {
+                curveNode.curves['x'] = animationCurve;
+              } else if (animationCurveRelationship.match(/Y/)) {
+                curveNode.curves['y'] = animationCurve;
+              } else if (animationCurveRelationship.match(/Z/)) {
+                curveNode.curves['z'] = animationCurve;
+              } else if (animationCurveRelationship.match(/DeformPercent/)) {
+                curveNode.curves['morph'] = animationCurve;
+              }
+            }
+          }
+        }
+      }
+
+    }
+
+  }
+
+  // parse nodes in FBXTree.Objects.AnimationLayer. Each layers holds references
+  // to various AnimationCurveNodes and is referenced by an AnimationStack node
+  // note: theoretically a stack can have multiple layers, however in practice there always seems to be one per stack
+  parseAnimationLayers (curveNodesMap: Map<number, CurveNode>): Map<number, AnimationNode[]> {
+    const objects = global.fbxTree.Objects;
+
+    const animationLayer = objects?.AnimationLayer;
+    const models = objects?.Model;
+    const connections = global.connections;
+    const sceneGraph = global.sceneGraph;
+
+    if (!animationLayer || !connections || !models || !sceneGraph || !objects) {
+      throw new Error('FBXTree.Objects.AnimationLayer is undefined');
+    }
+
+    const rawLayers = animationLayer;
+
+    const layersMap = new Map();
+
+    for (const nodeID in rawLayers) {
+
+      const layerCurveNodes: AnimationNode[] = [];
+
+      const connection = connections.get(parseInt(nodeID));
+
+      if (connection !== undefined) {
+
+        // all the animationCurveNodes used in the layer
+        const children = connection.children;
+
+        children.forEach((child, i) =>{
+
+          if (curveNodesMap.has(child.ID)) {
+
+            const curveNode = curveNodesMap.get(child.ID);
+
+            if (!curveNode) {return;}
+            // check that the curves are defined for at least one axis, otherwise ignore the curveNode
+            if (curveNode.curves.x !== undefined || curveNode.curves.y !== undefined || curveNode.curves.z !== undefined) {
+
+              if (layerCurveNodes[ i ] === undefined) {
+
+                const modelID = connections.get(child.ID)?.parents.filter(parent => {
+
+                  return parent.relationship !== undefined;
+
+                })[ 0 ].ID;
+
+                if (modelID !== undefined) {
+
+                  const rawModel = models[ modelID.toString() ];
+
+                  if (rawModel === undefined) {
+
+                    console.warn('THREE.FBXLoader: Encountered a unused curve.', child);
+
+                    return;
+
+                  }
+
+                  const node: AnimationNode = {
+                    modelName: rawModel.attrName ? PropertyBinding.sanitizeNodeName(rawModel.attrName) : '',
+                    ID: rawModel.id,
+                    initialPosition: [0, 0, 0],
+                    initialRotation: [0, 0, 0],
+                    initialScale: [1, 1, 1],
+                  };
+
+                  sceneGraph.traverse(child => {
+
+                    if ((child as any).ID === rawModel.id) {
+
+                      node.transform = child.matrix;
+
+                      if (child.userData.transformData) {node.eulerOrder = child.userData.transformData.eulerOrder;}
+
+                    }
+
+                  });
+
+                  if (! node.transform) {node.transform = new Matrix4();}
+
+                  // if the animated model is pre rotated, we'll have to apply the pre rotations to every
+                  // animation value as well
+                  if ('PreRotation' in rawModel) {node.preRotation = rawModel.PreRotation.value;}
+                  if ('PostRotation' in rawModel) {node.postRotation = rawModel.PostRotation.value;}
+                  layerCurveNodes[ i ] = node;
+
+                }
+
+              }
+
+              if (layerCurveNodes[ i ]) {
+                switch (curveNode.attr) {
+                  case 'T':
+                    layerCurveNodes[ i ].T = curveNode;
+
+                    break;
+                  case 'R':
+                    layerCurveNodes[ i ].R = curveNode;
+
+                    break;
+                  case 'S':
+                    layerCurveNodes[ i ].S = curveNode;
+
+                    break;
+                  case 'DeformPercent':
+                    layerCurveNodes[ i ].DeformPercent = curveNode;
+
+                    break;
+                  default:
+                    break;
+                }
+                // layerCurveNodes[ i ][ curveNode.attr ] = curveNode;
+              }
+
+            } else if (curveNode.curves.morph !== undefined) {
+
+              if (layerCurveNodes[ i ] === undefined) {
+
+                const deformerID = connections.get(child.ID)?.parents.filter(parent => {
+
+                  return parent.relationship !== undefined;
+
+                })[ 0 ].ID || 0;
+                const morpherID = connections.get(deformerID)?.parents[ 0 ].ID || 0;
+                const geoID = connections.get(morpherID)?.parents[ 0 ].ID || 0;
+
+                // assuming geometry is not used in more than one model
+                const modelID = connections.get(geoID)?.parents[ 0 ].ID || 0;
+                const models = objects.Model;
+
+                if (!models) {
+                  throw new Error('FBXTree.Objects.Model is undefined');
+                }
+                const rawModel = models[ modelID ];
+
+                const node: AnimationNode = {
+                  modelName: rawModel.attrName ? PropertyBinding.sanitizeNodeName(rawModel.attrName) : '',
+                  morphName: objects.Deformer[deformerID].attrName,
+                  ID: 0,
+                  initialPosition: [],
+                  initialRotation: [],
+                  initialScale: [],
+                };
+
+                layerCurveNodes[ i ] = node;
+
+              }
+              if (layerCurveNodes[ i ] !== undefined) {
+                switch (curveNode.attr) {
+                  case 'T':
+                    layerCurveNodes[ i ].T = curveNode;
+
+                    break;
+                  case 'R':
+                    layerCurveNodes[ i ].R = curveNode;
+
+                    break;
+                  case 'S':
+                    layerCurveNodes[ i ].S = curveNode;
+
+                    break;
+                  case 'DeformPercent':
+                    layerCurveNodes[ i ].DeformPercent = curveNode;
+
+                    break;
+                  default:
+                    break;
+                }
+              }
+              // layerCurveNodes[ i ][ attr ] = curveNode;
+              // layerCurveNodes[ i ]
+              // [ attr ] = curveNode;
+
+            }
+
+          }
+
+        });
+
+        layersMap.set(parseInt(nodeID), layerCurveNodes);
+
+      }
+
+    }
+
+    return layersMap;
+
+  }
+
+  // parse nodes in FBXTree.Objects.AnimationStack. These are the top level node in the animation
+  // hierarchy. Each Stack node will be used to create an AnimationClip
+  parseAnimStacks (layersMap: Map<number, AnimationNode[]>) {
+
+    const rawStacks = global.fbxTree.Objects?.AnimationStack;
+    const connections = global.connections;
+
+    if (!rawStacks || !connections) {
+      throw new Error('FBXTree.Objects.AnimationStack or global.connections is undefined');
+    }
+
+    // connect the stacks (clips) up to the layers
+    const rawClips: Record<string, RawClip> = {};
+
+    for (const nodeID in rawStacks) {
+
+      const children = connections.get(parseInt(nodeID))?.children || [];
+
+      if (children.length > 1) {
+
+        // it seems like stacks will always be associated with a single layer. But just in case there are files
+        // where there are multiple layers per stack, we'll display a warning
+        console.warn('THREE.FBXLoader: Encountered an animation stack with multiple layers, this is currently not supported. Ignoring subsequent layers.');
+
+      }
+
+      const layer = layersMap.get(children[ 0 ].ID);
+
+      if (!layer) {
+        throw new Error('Layer not found for nodeID: ' + nodeID);
+      }
+
+      rawClips[ nodeID ] = {
+
+        name: rawStacks[ nodeID ].attrName,
+        layer: layer,
+
+      };
+
+    }
+
+    return rawClips;
+
+  }
+
+  addClip (rawClip: RawClip) {
+
+    let tracks: (VectorKeyframeTrack | QuaternionKeyframeTrack | NumberKeyframeTrack)[] = [];
+
+    rawClip.layer.forEach(rawTracks=> {
+
+      tracks = tracks.concat(this.generateTracks(rawTracks));
+
+    });
+
+    return new AnimationClip(rawClip.name, - 1, tracks);
+
+  }
+
+  generateTracks (rawTracks: AnimationNode) {
+    const tracks: (VectorKeyframeTrack | QuaternionKeyframeTrack | NumberKeyframeTrack)[] = [];
+
+    let initialPosition: Vector3 | [number, number, number] = new Vector3();
+    let initialScale: Vector3 | [number, number, number] = new Vector3();
+
+    if (rawTracks.transform) {rawTracks.transform.decompose(initialPosition, new Quaternion(), initialScale);}
+
+    initialPosition = initialPosition.toArray();
+    initialScale = initialScale.toArray();
+
+    if (rawTracks.T !== undefined && Object.keys(rawTracks.T.curves).length > 0) {
+
+      const positionTrack = this.generateVectorTrack(rawTracks.modelName, rawTracks.T.curves, initialPosition, 'position');
+
+      if (positionTrack !== undefined) {tracks.push(positionTrack);}
+
+    }
+
+    if (rawTracks.R !== undefined && Object.keys(rawTracks.R.curves).length > 0) {
+
+      const rotationTrack = this.generateRotationTrack(rawTracks.modelName, rawTracks.R.curves, rawTracks.preRotation ?? [0, 0, 0], rawTracks.postRotation ?? [0, 0, 0], rawTracks.eulerOrder || 'ZYX');
+
+      if (rotationTrack !== undefined) {tracks.push(rotationTrack);}
+
+    }
+
+    if (rawTracks.S !== undefined && Object.keys(rawTracks.S.curves).length > 0) {
+
+      const scaleTrack = this.generateVectorTrack(rawTracks.modelName, rawTracks.S.curves, initialScale, 'scale');
+
+      if (scaleTrack !== undefined) {tracks.push(scaleTrack);}
+
+    }
+
+    if (rawTracks.DeformPercent !== undefined) {
+
+      const morphTrack = this.generateMorphTrack(rawTracks);
+
+      if (morphTrack !== undefined) {tracks.push(morphTrack);}
+
+    }
+
+    return tracks;
+
+  }
+
+  generateVectorTrack (modelName: string, curves: { x?: AnimationCurve, y?: AnimationCurve, z?: AnimationCurve }, initialValue: [number, number, number], type: string) {
+
+    const times = this.getTimesForAllAxes(curves);
+    const values = this.getKeyframeTrackValues(times, curves, initialValue);
+
+    return new VectorKeyframeTrack(modelName + '.' + type, times, values);
+
+  }
+
+  generateRotationTrack (modelName: string, curves: { x?: AnimationCurve, y?: AnimationCurve, z?: AnimationCurve }, preRotation: [number, number, number], postRotation: [number, number, number], eulerOrder: EulerOrder) {
+
+    let times;
+    let values;
+    let preRotationQuat: number[] | Euler | Quaternion = preRotation;
+    let postRotationQuat: number[] | Euler | Quaternion = postRotation;
+
+    if (curves.x !== undefined && curves.y !== undefined && curves.z !== undefined) {
+
+      const result = this.interpolateRotations(curves.x, curves.y, curves.z, eulerOrder);
+
+      times = result[ 0 ];
+      values = result[ 1 ];
+
+    }
+
+    // For Maya models using "Joint Orient", Euler order only applies to rotation, not pre/post-rotations
+    const defaultEulerOrder = getEulerOrder(0) as EulerOrder;
+
+    if (preRotationQuat !== undefined) {
+
+      preRotationQuat = preRotationQuat.map(MathUtils.degToRad);
+      // preRotation.push(defaultEulerOrder);
+
+      preRotationQuat = new Euler(preRotationQuat[0], preRotationQuat[1], preRotationQuat[2], defaultEulerOrder);
+      preRotationQuat = new Quaternion().setFromEuler(preRotationQuat);
+
+    }
+
+    if (postRotationQuat !== undefined) {
+
+      postRotationQuat = postRotationQuat.map(MathUtils.degToRad);
+      // postRotationQuat.push(defaultEulerOrder);
+
+      postRotationQuat = new Euler(postRotationQuat[0], postRotationQuat[1], postRotationQuat[2], defaultEulerOrder);
+      postRotationQuat = new Quaternion().setFromEuler(postRotationQuat).invert();
+
+      // postRotation = new Euler().fromArray(postRotation);
+      // postRotation = new Quaternion().setFromEuler(postRotation).invert();
+
+    }
+
+    const quaternion = new Quaternion();
+    const euler = new Euler();
+
+    const quaternionValues: number[] = [];
+
+    if (! values || ! times) {return new QuaternionKeyframeTrack(modelName + '.quaternion', [0], [0]);}
+
+    for (let i = 0; i < values.length; i += 3) {
+
+      euler.set(values[ i ], values[ i + 1 ], values[ i + 2 ], eulerOrder);
+      quaternion.setFromEuler(euler);
+
+      if (preRotationQuat !== undefined) {quaternion.premultiply(preRotationQuat);}
+      if (postRotationQuat !== undefined) {quaternion.multiply(postRotationQuat);}
+
+      // Check unroll
+      if (i > 2) {
+
+        const prevQuat = new Quaternion().fromArray(
+          quaternionValues,
+          ((i - 3) / 3) * 4
+        );
+
+        if (prevQuat.dot(quaternion) < 0) {
+
+          quaternion.set(- quaternion.x, - quaternion.y, - quaternion.z, - quaternion.w);
+
+        }
+
+      }
+
+      quaternion.toArray(quaternionValues, (i / 3) * 4);
+
+    }
+
+    return new QuaternionKeyframeTrack(modelName + '.quaternion', times, quaternionValues);
+
+  }
+
+  generateMorphTrack (rawTracks: AnimationNode) {
+    const curves = rawTracks.DeformPercent?.curves.morph;
+
+    if (!curves) {
+      throw new Error('curves is undefined');
+    }
+    const sceneGraph = global.sceneGraph;
+
+    if (!sceneGraph) {
+      throw new Error('sceneGraph is undefined');
+    }
+    const values = curves.values.map(val => {
+
+      return val / 100;
+
+    }) || [];
+    const object = sceneGraph.getObjectByName(rawTracks.modelName);
+
+    const morphNum = (object as any).morphTargetDictionary[ rawTracks.morphName ?? '' ];
+
+    return new NumberKeyframeTrack(rawTracks.modelName + '.morphTargetInfluences[' + morphNum + ']', curves.times, values);
+
+  }
+
+  // For all animated objects, times are defined separately for each axis
+  // Here we'll combine the times into one sorted array without duplicates
+  getTimesForAllAxes (curves: {
+    x?: AnimationCurve,
+    y?: AnimationCurve,
+    z?: AnimationCurve,
+    morph?: AnimationCurve,
+  }) {
+    let times: number[] = [];
+
+    // first join together the times for each axis, if defined
+    if (curves.x !== undefined) {times = times.concat(curves.x.times);}
+    if (curves.y !== undefined) {times = times.concat(curves.y.times);}
+    if (curves.z !== undefined) {times = times.concat(curves.z.times);}
+
+    // then sort them
+    times = times.sort(function (a, b) {
+
+      return a - b;
+
+    });
+
+    // and remove duplicates
+    if (times.length > 1) {
+
+      let targetIndex = 1;
+      let lastValue = times[ 0 ];
+
+      for (let i = 1; i < times.length; i ++) {
+
+        const currentValue = times[ i ];
+
+        if (currentValue !== lastValue) {
+
+          times[ targetIndex ] = currentValue;
+          lastValue = currentValue;
+          targetIndex ++;
+
+        }
+
+      }
+
+      times = times.slice(0, targetIndex);
+
+    }
+
+    return times;
+
+  }
+
+  getKeyframeTrackValues (times: number[], curves: {
+    x?: AnimationCurve,
+    y?: AnimationCurve,
+    z?: AnimationCurve,
+    morph?: AnimationCurve,
+  }, initialValue: [number, number, number]) {
+    const prevValue = initialValue;
+
+    const values: number[] = [];
+
+    let xIndex = - 1;
+    let yIndex = - 1;
+    let zIndex = - 1;
+
+    times.forEach(function (time) {
+
+      if (curves.x) {xIndex = curves.x.times.indexOf(time);}
+      if (curves.y) {yIndex = curves.y.times.indexOf(time);}
+      if (curves.z) {zIndex = curves.z.times.indexOf(time);}
+
+      // if there is an x value defined for this frame, use that
+      if (xIndex !== - 1) {
+
+        const xValue = curves.x?.values[ xIndex ] || 0;
+
+        values.push(xValue);
+        prevValue[ 0 ] = xValue;
+
+      } else {
+
+        // otherwise use the x value from the previous frame
+        values.push(prevValue[ 0 ]);
+
+      }
+
+      if (yIndex !== - 1) {
+
+        const yValue = curves.y?.values[ yIndex ] || 0;
+
+        values.push(yValue);
+        prevValue[ 1 ] = yValue;
+
+        values.push(yValue);
+        prevValue[ 1 ] = yValue;
+
+      } else {
+
+        values.push(prevValue[ 1 ]);
+
+      }
+
+      if (zIndex !== - 1) {
+
+        const zValue = curves.z?.values[ zIndex ] || 0;
+
+        values.push(zValue);
+        prevValue[ 2 ] = zValue;
+
+      } else {
+
+        values.push(prevValue[ 2 ]);
+
+      }
+
+    });
+
+    return values;
+
+  }
+
+  // Rotations are defined as Euler angles which can have values  of any size
+  // These will be converted to quaternions which don't support values greater than
+  // PI, so we'll interpolate large rotations
+  interpolateRotations (curvex: AnimationCurve, curvey: AnimationCurve, curvez: AnimationCurve, eulerOrder: EulerOrder) {
+    const times = [];
+    const values = [];
+
+    // Add first frame
+    times.push(curvex.times[ 0 ]);
+    values.push(MathUtils.degToRad(curvex.values[ 0 ]));
+    values.push(MathUtils.degToRad(curvey.values[ 0 ]));
+    values.push(MathUtils.degToRad(curvez.values[ 0 ]));
+
+    for (let i = 1; i < curvex.values.length; i ++) {
+
+      const initialValue = [
+        curvex.values[ i - 1 ],
+        curvey.values[ i - 1 ],
+        curvez.values[ i - 1 ],
+      ];
+
+      if (isNaN(initialValue[ 0 ]) || isNaN(initialValue[ 1 ]) || isNaN(initialValue[ 2 ])) {
+
+        continue;
+
+      }
+
+      const initialValueRad = initialValue.map(MathUtils.degToRad);
+
+      const currentValue = [
+        curvex.values[ i ],
+        curvey.values[ i ],
+        curvez.values[ i ],
+      ];
+
+      if (isNaN(currentValue[ 0 ]) || isNaN(currentValue[ 1 ]) || isNaN(currentValue[ 2 ])) {
+
+        continue;
+
+      }
+
+      const currentValueRad = currentValue.map(MathUtils.degToRad);
+
+      const valuesSpan = [
+        currentValue[ 0 ] - initialValue[ 0 ],
+        currentValue[ 1 ] - initialValue[ 1 ],
+        currentValue[ 2 ] - initialValue[ 2 ],
+      ];
+
+      const absoluteSpan = [
+        Math.abs(valuesSpan[ 0 ]),
+        Math.abs(valuesSpan[ 1 ]),
+        Math.abs(valuesSpan[ 2 ]),
+      ];
+
+      if (absoluteSpan[ 0 ] >= 180 || absoluteSpan[ 1 ] >= 180 || absoluteSpan[ 2 ] >= 180) {
+
+        const maxAbsSpan = Math.max(...absoluteSpan);
+
+        const numSubIntervals = maxAbsSpan / 180;
+
+        const E1 = new Euler(initialValueRad[0], initialValueRad[1], initialValueRad[2], eulerOrder);
+        const E2 = new Euler(currentValueRad[0], currentValueRad[1], currentValueRad[2], eulerOrder);
+
+        const Q1 = new Quaternion().setFromEuler(E1);
+        const Q2 = new Quaternion().setFromEuler(E2);
+
+        // Check unroll
+        if (Q1.dot(Q2)) {
+
+          Q2.set(- Q2.x, - Q2.y, - Q2.z, - Q2.w);
+
+        }
+
+        // Interpolate
+        const initialTime = curvex.times[ i - 1 ];
+        const timeSpan = curvex.times[ i ] - initialTime;
+
+        const Q = new Quaternion();
+        const E = new Euler();
+
+        for (let t = 0; t < 1; t += 1 / numSubIntervals) {
+
+          Q.copy(Q1.clone().slerp(Q2.clone(), t));
+
+          times.push(initialTime + t * timeSpan);
+          E.setFromQuaternion(Q, eulerOrder);
+
+          values.push(E.x);
+          values.push(E.y);
+          values.push(E.z);
+
+        }
+
+      } else {
+
+        times.push(curvex.times[ i ]);
+        values.push(MathUtils.degToRad(curvex.values[ i ]));
+        values.push(MathUtils.degToRad(curvey.values[ i ]));
+        values.push(MathUtils.degToRad(curvez.values[ i ]));
+
+      }
+
+    }
+
+    return [times, values];
+
+  }
+
+}

--- a/src/parse/FBX-geometry-parser.ts
+++ b/src/parse/FBX-geometry-parser.ts
@@ -1,0 +1,1030 @@
+import type { EulerOrder, Matrix4 } from 'three';
+import { BufferGeometry, Float32BufferAttribute, Uint16BufferAttribute, Matrix3, Vector3, Vector2, ShapeUtils, Color, ColorManagement, SRGBColorSpace, Vector4 } from 'three';
+import { NURBSCurve } from '../curves/NURBS-curve';
+import { getEulerOrder, generateTransform, getData } from './utils';
+import type { Deformers, FBXConnectionNode, FBXEulerOrder, FBXGeometryNode, FBXLayerElementColor, FBXLayerElementNormal, FBXLayerElementUV, FBXMaterialNode, FBXMorphTarget, FBXSkeleton, UserDataTransform } from '../constants';
+import { global } from '../constants';
+
+interface GeoBufferInfo { dataSize: number, buffer: number[], indices: number[], mappingType: string, referenceType: string }
+interface GeoInfo {
+  material?: GeoBufferInfo,
+  vertexPositions?: number[],
+  vertexIndices?: any[],
+  baseVertexPositions?: number[],
+  color?: GeoBufferInfo,
+  normal?: GeoBufferInfo,
+  uv?: {
+    dataSize: number,
+    buffer: any[],
+    indices: any[],
+    mappingType: string,
+    referenceType: string,
+  }[],
+  weightTable?: {
+    [key: number]: Array<{ id: number, weight: number }>,
+  },
+  skeleton?: FBXSkeleton,
+}
+
+export class GeometryParser {
+  negativeMaterialIndices: boolean;
+
+  constructor () {
+
+    this.negativeMaterialIndices = false;
+
+  }
+
+  // Parse nodes in FBXTree.Objects.Geometry
+  parse (deformers: Deformers) {
+
+    const geometryMap = new Map();
+    const fbxTree = global.fbxTree;
+    const connections = global.connections;
+
+    if (!fbxTree || !connections) {
+      throw new Error('FBXTree or connections is not defined');
+    }
+    const objects = fbxTree.Objects;
+
+    if (!objects) {
+      throw new Error('Objects is not defined in FBXTree');
+    }
+
+    if ('Geometry' in objects) {
+
+      const geoNodes = objects.Geometry;
+
+      for (const nodeID in geoNodes) {
+
+        const relationships = connections.get(parseInt(nodeID)) || { parents: [], children: [] };
+        const geo = this.parseGeometry(relationships, geoNodes[ nodeID ], deformers);
+
+        geometryMap.set(parseInt(nodeID), geo);
+
+      }
+
+    }
+
+    // report warnings
+
+    if (this.negativeMaterialIndices === true) {
+
+      console.warn('THREE.FBXLoader: The FBX file contains invalid (negative) material indices. The asset might not render as expected.');
+
+    }
+
+    return geometryMap;
+
+  }
+
+  // Parse single node in FBXTree.Objects.Geometry
+  parseGeometry (relationships: FBXConnectionNode, geoNode: FBXGeometryNode, deformers: Deformers) {
+
+    switch (geoNode.attrType) {
+
+      case 'Mesh':
+        return this.parseMeshGeometry(relationships, geoNode, deformers);
+
+        break;
+      case 'NurbsCurve':
+        return this.parseNurbsGeometry(geoNode);
+
+        break;
+
+    }
+
+  }
+
+  // Parse single node mesh geometry in FBXTree.Objects.Geometry
+  parseMeshGeometry (relationships: FBXConnectionNode, geoNode: FBXGeometryNode, deformers: Deformers) {
+
+    const skeletons = deformers.skeletons;
+    const morphTargets: FBXMorphTarget[] = [];
+    const fbxTreeObjects = global.fbxTree.Objects;
+
+    if (!fbxTreeObjects) {
+      throw new Error('Objects is not defined in FBXTree');
+    }
+
+    const models = fbxTreeObjects.Model;
+
+    if (!models) {
+      throw new Error('Model is not defined in FBXTree.Objects');
+    }
+
+    const modelNodes = relationships.parents.map(parent => {
+
+      return models[ parent.ID ];
+
+    });
+
+    // don't create geometry if it is not associated with any models
+    if (modelNodes.length === 0) {return;}
+
+    const skeleton = relationships.children.reduce<FBXSkeleton | null>((skeleton, child) =>{
+      const childID = child.ID;
+
+      if (childID !== undefined && skeletons[childID]) {
+        skeleton = skeletons[childID];
+      }
+
+      return skeleton;
+
+    }, null);
+
+    relationships.children.forEach(child=> {
+
+      if (deformers.morphTargets[ child.ID ] !== undefined) {
+
+        morphTargets.push(deformers.morphTargets[ child.ID ]);
+
+      }
+
+    });
+
+    // Assume one model and get the preRotation from that
+    // if there is more than one model associated with the geometry this may cause problems
+    const modelNode = modelNodes[ 0 ];
+
+    const transformData: UserDataTransform = {};
+
+    if ('RotationOrder' in modelNode) {
+      const value = modelNode.RotationOrder.value;
+
+      if (typeof value === 'number') {
+        transformData.eulerOrder = getEulerOrder(modelNode.RotationOrder.value as FBXEulerOrder) as EulerOrder;
+      }
+
+    }
+    if ('InheritType' in modelNode) {transformData.inheritType = parseInt(modelNode.InheritType.value);}
+
+    if ('GeometricTranslation' in modelNode) {transformData.translation = modelNode.GeometricTranslation.value;}
+    if ('GeometricRotation' in modelNode) {transformData.rotation = modelNode.GeometricRotation.value;}
+    if ('GeometricScaling' in modelNode) {transformData.scale = modelNode.GeometricScaling.value;}
+
+    const transform = generateTransform(transformData);
+
+    return this.genGeometry(geoNode, skeleton, morphTargets, transform);
+
+  }
+
+  // Generate a BufferGeometry from a node in FBXTree.Objects.Geometry
+  genGeometry (geoNode: FBXGeometryNode, skeleton: FBXSkeleton | null, morphTargets: FBXMorphTarget[], preTransform: Matrix4) {
+
+    const geo = new BufferGeometry();
+
+    if (geoNode.attrName) {geo.name = geoNode.attrName;}
+
+    const geoInfo = this.parseGeoNode(geoNode, skeleton);
+    const buffers = this.genBuffers(geoInfo);
+
+    const positionAttribute = new Float32BufferAttribute(buffers.vertex, 3);
+
+    positionAttribute.applyMatrix4(preTransform);
+
+    geo.setAttribute('position', positionAttribute);
+
+    if (buffers.colors.length > 0) {
+
+      geo.setAttribute('color', new Float32BufferAttribute(buffers.colors, 3));
+
+    }
+
+    if (skeleton) {
+
+      geo.setAttribute('skinIndex', new Uint16BufferAttribute(buffers.weightsIndices, 4));
+
+      geo.setAttribute('skinWeight', new Float32BufferAttribute(buffers.vertexWeights, 4));
+
+      // used later to bind the skeleton to the model
+      (geo as any).FBX_Deformer = skeleton;
+
+    }
+
+    if (buffers.normal.length > 0) {
+
+      const normalMatrix = new Matrix3().getNormalMatrix(preTransform);
+
+      const normalAttribute = new Float32BufferAttribute(buffers.normal, 3);
+
+      normalAttribute.applyNormalMatrix(normalMatrix);
+
+      geo.setAttribute('normal', normalAttribute);
+
+    }
+
+    buffers.uvs.forEach(function (uvBuffer, i) {
+
+      const name = i === 0 ? 'uv' : `uv${ i }`;
+
+      geo.setAttribute(name, new Float32BufferAttribute(buffers.uvs[ i ], 2));
+
+    });
+
+    if (geoInfo.material && geoInfo.material.mappingType !== 'AllSame') {
+
+      // Convert the material indices of each vertex into rendering groups on the geometry.
+      let prevMaterialIndex = buffers.materialIndex[ 0 ];
+      let startIndex = 0;
+
+      buffers.materialIndex.forEach(function (currentIndex, i) {
+
+        if (currentIndex !== prevMaterialIndex) {
+
+          geo.addGroup(startIndex, i - startIndex, prevMaterialIndex);
+
+          prevMaterialIndex = currentIndex;
+          startIndex = i;
+
+        }
+
+      });
+
+      // the loop above doesn't add the last group, do that here.
+      if (geo.groups.length > 0) {
+
+        const lastGroup = geo.groups[ geo.groups.length - 1 ];
+        const lastIndex = lastGroup.start + lastGroup.count;
+
+        if (lastIndex !== buffers.materialIndex.length) {
+
+          geo.addGroup(lastIndex, buffers.materialIndex.length - lastIndex, prevMaterialIndex);
+
+        }
+
+      }
+
+      // case where there are multiple materials but the whole geometry is only
+      // using one of them
+      if (geo.groups.length === 0) {
+
+        geo.addGroup(0, buffers.materialIndex.length, buffers.materialIndex[ 0 ]);
+
+      }
+
+    }
+
+    this.addMorphTargets(geo, geoNode, morphTargets, preTransform);
+
+    return geo;
+
+  }
+
+  parseGeoNode (geoNode: FBXGeometryNode, skeleton: FBXSkeleton | null): GeoInfo {
+
+    const geoInfo: GeoInfo = {
+    };
+
+    geoInfo.vertexPositions = (geoNode.Vertices !== undefined) ? geoNode.Vertices.a : [];
+    geoInfo.vertexIndices = (geoNode.PolygonVertexIndex !== undefined) ? geoNode.PolygonVertexIndex.a : [];
+
+    if (geoNode.LayerElementColor) {
+
+      geoInfo.color = this.parseVertexColors(geoNode.LayerElementColor[ 0 ]);
+
+    }
+
+    if (geoNode.LayerElementMaterial) {
+
+      geoInfo.material = this.parseMaterialIndices(geoNode.LayerElementMaterial[ 0 ]);
+
+    }
+
+    if (geoNode.LayerElementNormal) {
+
+      geoInfo.normal = this.parseNormals(geoNode.LayerElementNormal[ 0 ]);
+
+    }
+
+    if (geoNode.LayerElementUV) {
+
+      geoInfo.uv = [];
+
+      let i = 0;
+
+      while (geoNode.LayerElementUV[ i ]) {
+
+        if (geoNode.LayerElementUV[ i ].UV) {
+
+          geoInfo.uv.push(this.parseUVs(geoNode.LayerElementUV[ i ]));
+
+        }
+
+        i ++;
+
+      }
+
+    }
+
+    geoInfo.weightTable = {};
+
+    if (skeleton !== null) {
+
+      geoInfo.skeleton = skeleton;
+
+      skeleton.rawBones.forEach(function (rawBone, i) {
+
+        // loop over the bone's vertex indices and weights
+        rawBone.indices.forEach(function (index, j) {
+
+          if (geoInfo.weightTable && geoInfo.weightTable[ index ] === undefined) {
+            geoInfo.weightTable[ index ] = [];
+          }
+
+          if (geoInfo.weightTable) {
+            geoInfo.weightTable[ index ].push({
+              id: i,
+              weight: rawBone.weights[ j ],
+            });
+          }
+
+        });
+
+      });
+
+    }
+
+    return geoInfo;
+
+  }
+
+  genBuffers (geoInfo: GeoInfo) {
+
+    const buffers = {
+      vertex: [],
+      normal: [],
+      colors: [],
+      uvs: [],
+      materialIndex: [],
+      vertexWeights: [],
+      weightsIndices: [],
+    };
+
+    let polygonIndex = 0;
+    let faceLength = 0;
+    let displayedWeightsWarning = false;
+
+    // these will hold data for a single face
+    let facePositionIndexes: number[] = [];
+    let faceNormals: number[] = [];
+    let faceColors: number[] = [];
+    let faceUVs: number[][] = [];
+    let faceWeights: number[] = [];
+    let faceWeightIndices: number[] = [];
+
+    geoInfo.vertexIndices?.forEach((vertexIndex: number, polygonVertexIndex: number) =>{
+
+      let materialIndex: number | undefined;
+      let endOfFace = false;
+
+      // Face index and vertex index arrays are combined in a single array
+      // A cube with quad faces looks like this:
+      // PolygonVertexIndex: *24 {
+      //  a: 0, 1, 3, -3, 2, 3, 5, -5, 4, 5, 7, -7, 6, 7, 1, -1, 1, 7, 5, -4, 6, 0, 2, -5
+      //  }
+      // Negative numbers mark the end of a face - first face here is 0, 1, 3, -3
+      // to find index of last vertex bit shift the index: ^ - 1
+      if (vertexIndex < 0) {
+
+        vertexIndex = vertexIndex ^ - 1; // equivalent to ( x * -1 ) - 1
+        endOfFace = true;
+
+      }
+
+      let weightIndices: number[] = [];
+      let weights: number[] = [];
+
+      facePositionIndexes.push(vertexIndex * 3, vertexIndex * 3 + 1, vertexIndex * 3 + 2);
+
+      if (geoInfo.color) {
+
+        const data = getData(polygonVertexIndex, polygonIndex, vertexIndex, geoInfo.color);
+
+        faceColors.push(data[ 0 ], data[ 1 ], data[ 2 ]);
+
+      }
+
+      if (geoInfo.skeleton && geoInfo.weightTable) {
+
+        if (geoInfo.weightTable[ vertexIndex ] !== undefined) {
+
+          geoInfo.weightTable[ vertexIndex ].forEach(function (wt) {
+
+            weights.push(wt.weight);
+            weightIndices.push(wt.id);
+
+          });
+
+        }
+
+        if (weights.length > 4) {
+
+          if (! displayedWeightsWarning) {
+
+            console.warn('THREE.FBXLoader: Vertex has more than 4 skinning weights assigned to vertex. Deleting additional weights.');
+            displayedWeightsWarning = true;
+
+          }
+
+          const wIndex = [0, 0, 0, 0];
+          const Weight = [0, 0, 0, 0];
+
+          weights.forEach(function (weight, weightIndex) {
+
+            let currentWeight = weight;
+            let currentIndex = weightIndices[ weightIndex ];
+
+            Weight.forEach(function (comparedWeight, comparedWeightIndex, comparedWeightArray) {
+
+              if (currentWeight > comparedWeight) {
+
+                comparedWeightArray[ comparedWeightIndex ] = currentWeight;
+                currentWeight = comparedWeight;
+
+                const tmp = wIndex[ comparedWeightIndex ];
+
+                wIndex[ comparedWeightIndex ] = currentIndex;
+                currentIndex = tmp;
+
+              }
+
+            });
+
+          });
+
+          weightIndices = wIndex;
+          weights = Weight;
+
+        }
+
+        // if the weight array is shorter than 4 pad with 0s
+        while (weights.length < 4) {
+
+          weights.push(0);
+          weightIndices.push(0);
+
+        }
+
+        for (let i = 0; i < 4; ++ i) {
+
+          faceWeights.push(weights[ i ]);
+          faceWeightIndices.push(weightIndices[ i ]);
+
+        }
+
+      }
+
+      if (geoInfo.normal) {
+
+        const data = getData(polygonVertexIndex, polygonIndex, vertexIndex, geoInfo.normal);
+
+        faceNormals.push(data[ 0 ], data[ 1 ], data[ 2 ]);
+
+      }
+
+      if (geoInfo.material && geoInfo.material.mappingType !== 'AllSame') {
+
+        materialIndex = getData(polygonVertexIndex, polygonIndex, vertexIndex, geoInfo.material)[ 0 ];
+
+        if (materialIndex < 0) {
+
+          this.negativeMaterialIndices = true;
+          materialIndex = 0; // fallback
+
+        }
+
+      }
+
+      if (geoInfo.uv) {
+
+        geoInfo.uv.forEach((uv, i) => {
+
+          const data = getData(polygonVertexIndex, polygonIndex, vertexIndex, uv);
+
+          if (faceUVs[ i ] === undefined) {
+
+            faceUVs[ i ] = [];
+
+          }
+
+          faceUVs[ i ].push(data[ 0 ]);
+          faceUVs[ i ].push(data[ 1 ]);
+
+        });
+
+      }
+
+      faceLength ++;
+
+      if (endOfFace) {
+
+        this.genFace(buffers, geoInfo, facePositionIndexes, materialIndex ?? 0, faceNormals, faceColors, faceUVs, faceWeights, faceWeightIndices, faceLength);
+
+        polygonIndex ++;
+        faceLength = 0;
+
+        // reset arrays for the next face
+        facePositionIndexes = [];
+        faceNormals = [];
+        faceColors = [];
+        faceUVs = [];
+        faceWeights = [];
+        faceWeightIndices = [];
+
+      }
+
+    });
+
+    return buffers;
+
+  }
+
+  // See https://www.khronos.org/opengl/wiki/Calculating_a_Surface_Normal
+  getNormalNewell (vertices: Vector3[]): Vector3 {
+
+    const normal = new Vector3(0.0, 0.0, 0.0);
+
+    for (let i = 0; i < vertices.length; i ++) {
+
+      const current = vertices[ i ];
+      const next = vertices[ (i + 1) % vertices.length ];
+
+      normal.x += (current.y - next.y) * (current.z + next.z);
+      normal.y += (current.z - next.z) * (current.x + next.x);
+      normal.z += (current.x - next.x) * (current.y + next.y);
+
+    }
+
+    normal.normalize();
+
+    return normal;
+
+  }
+
+  getNormalTangentAndBitangent (vertices: Vector3[]) {
+
+    const normalVector = this.getNormalNewell(vertices);
+    // Avoid up being equal or almost equal to normalVector
+    const up = Math.abs(normalVector.z) > 0.5 ? new Vector3(0.0, 1.0, 0.0) : new Vector3(0.0, 0.0, 1.0);
+    const tangent = up.cross(normalVector).normalize();
+    const bitangent = normalVector.clone().cross(tangent).normalize();
+
+    return {
+      normal: normalVector,
+      tangent: tangent,
+      bitangent: bitangent,
+    };
+
+  }
+
+  flattenVertex (vertex: Vector3, normalTangent: Vector3, normalBitangent: Vector3): Vector2 {
+
+    return new Vector2(
+      vertex.dot(normalTangent),
+      vertex.dot(normalBitangent)
+    );
+
+  }
+
+  // Generate data for a single face in a geometry. If the face is a quad then split it into 2 tris
+  genFace (
+    buffers: {
+      vertex: number[],
+      normal: number[],
+      colors: number[],
+      uvs: number[][],
+      materialIndex: number[],
+      vertexWeights: number[],
+      weightsIndices: number[],
+    },
+    geoInfo: GeoInfo,
+    facePositionIndexes: number[],
+    materialIndex: number,
+    faceNormals: number[],
+    faceColors: number[],
+    faceUVs: number[][],
+    faceWeights: number[],
+    faceWeightIndices: number[],
+    faceLength: number
+  ) {
+
+    let triangles;
+
+    if (faceLength > 3) {
+
+      // Triangulate n-gon using earcut
+
+      const vertices = [];
+      // in morphing scenario vertexPositions represent morphPositions
+      // while baseVertexPositions represent the original geometry's positions
+      const positions = geoInfo.baseVertexPositions || geoInfo.vertexPositions || [];
+
+      for (let i = 0; i < facePositionIndexes.length; i += 3) {
+
+        vertices.push(
+          new Vector3(
+            positions[ facePositionIndexes[ i ] ],
+            positions[ facePositionIndexes[ i + 1 ] ],
+            positions[ facePositionIndexes[ i + 2 ] ]
+          )
+        );
+
+      }
+
+      const { tangent, bitangent } = this.getNormalTangentAndBitangent(vertices);
+      const triangulationInput = [];
+
+      for (const vertex of vertices) {
+
+        triangulationInput.push(this.flattenVertex(vertex, tangent, bitangent));
+
+      }
+
+      // When vertices is an array of [0,0,0] elements (which is the case for vertices not participating in morph)
+      // the triangulationInput will be an array of [0,0] elements
+      // resulting in an array of 0 triangles being returned from ShapeUtils.triangulateShape
+      // leading to not pushing into buffers.vertex the redundant vertices (the vertices that are not morphed).
+      // That's why, in order to support morphing scenario, "positions" is looking first for baseVertexPositions,
+      // so that we don't end up with an array of 0 triangles for the faces not participating in morph.
+      triangles = ShapeUtils.triangulateShape(triangulationInput, []);
+
+    } else {
+
+      // Regular triangle, skip earcut triangulation step
+      triangles = [[0, 1, 2]];
+
+    }
+    if (geoInfo.vertexPositions === undefined) {
+      throw new Error('vertexPositions is not defined in geoInfo');
+    }
+    for (const [i0, i1, i2] of triangles) {
+
+      buffers.vertex.push(geoInfo.vertexPositions[ facePositionIndexes[ i0 * 3 ] ]);
+      buffers.vertex.push(geoInfo.vertexPositions[ facePositionIndexes[ i0 * 3 + 1 ] ]);
+      buffers.vertex.push(geoInfo.vertexPositions[ facePositionIndexes[ i0 * 3 + 2 ] ]);
+
+      buffers.vertex.push(geoInfo.vertexPositions[ facePositionIndexes[ i1 * 3 ] ]);
+      buffers.vertex.push(geoInfo.vertexPositions[ facePositionIndexes[ i1 * 3 + 1 ] ]);
+      buffers.vertex.push(geoInfo.vertexPositions[ facePositionIndexes[ i1 * 3 + 2 ] ]);
+
+      buffers.vertex.push(geoInfo.vertexPositions[ facePositionIndexes[ i2 * 3 ] ]);
+      buffers.vertex.push(geoInfo.vertexPositions[ facePositionIndexes[ i2 * 3 + 1 ] ]);
+      buffers.vertex.push(geoInfo.vertexPositions[ facePositionIndexes[ i2 * 3 + 2 ] ]);
+
+      if (geoInfo.skeleton) {
+
+        buffers.vertexWeights.push(faceWeights[ i0 * 4 ]);
+        buffers.vertexWeights.push(faceWeights[ i0 * 4 + 1 ]);
+        buffers.vertexWeights.push(faceWeights[ i0 * 4 + 2 ]);
+        buffers.vertexWeights.push(faceWeights[ i0 * 4 + 3 ]);
+
+        buffers.vertexWeights.push(faceWeights[ i1 * 4 ]);
+        buffers.vertexWeights.push(faceWeights[ i1 * 4 + 1 ]);
+        buffers.vertexWeights.push(faceWeights[ i1 * 4 + 2 ]);
+        buffers.vertexWeights.push(faceWeights[ i1 * 4 + 3 ]);
+
+        buffers.vertexWeights.push(faceWeights[ i2 * 4 ]);
+        buffers.vertexWeights.push(faceWeights[ i2 * 4 + 1 ]);
+        buffers.vertexWeights.push(faceWeights[ i2 * 4 + 2 ]);
+        buffers.vertexWeights.push(faceWeights[ i2 * 4 + 3 ]);
+
+        buffers.weightsIndices.push(faceWeightIndices[ i0 * 4 ]);
+        buffers.weightsIndices.push(faceWeightIndices[ i0 * 4 + 1 ]);
+        buffers.weightsIndices.push(faceWeightIndices[ i0 * 4 + 2 ]);
+        buffers.weightsIndices.push(faceWeightIndices[ i0 * 4 + 3 ]);
+
+        buffers.weightsIndices.push(faceWeightIndices[ i1 * 4 ]);
+        buffers.weightsIndices.push(faceWeightIndices[ i1 * 4 + 1 ]);
+        buffers.weightsIndices.push(faceWeightIndices[ i1 * 4 + 2 ]);
+        buffers.weightsIndices.push(faceWeightIndices[ i1 * 4 + 3 ]);
+
+        buffers.weightsIndices.push(faceWeightIndices[ i2 * 4 ]);
+        buffers.weightsIndices.push(faceWeightIndices[ i2 * 4 + 1 ]);
+        buffers.weightsIndices.push(faceWeightIndices[ i2 * 4 + 2 ]);
+        buffers.weightsIndices.push(faceWeightIndices[ i2 * 4 + 3 ]);
+
+      }
+
+      if (geoInfo.color) {
+
+        buffers.colors.push(faceColors[ i0 * 3 ]);
+        buffers.colors.push(faceColors[ i0 * 3 + 1 ]);
+        buffers.colors.push(faceColors[ i0 * 3 + 2 ]);
+
+        buffers.colors.push(faceColors[ i1 * 3 ]);
+        buffers.colors.push(faceColors[ i1 * 3 + 1 ]);
+        buffers.colors.push(faceColors[ i1 * 3 + 2 ]);
+
+        buffers.colors.push(faceColors[ i2 * 3 ]);
+        buffers.colors.push(faceColors[ i2 * 3 + 1 ]);
+        buffers.colors.push(faceColors[ i2 * 3 + 2 ]);
+
+      }
+
+      if (geoInfo.material && geoInfo.material.mappingType !== 'AllSame') {
+
+        buffers.materialIndex.push(materialIndex);
+        buffers.materialIndex.push(materialIndex);
+        buffers.materialIndex.push(materialIndex);
+
+      }
+
+      if (geoInfo.normal) {
+
+        buffers.normal.push(faceNormals[ i0 * 3 ]);
+        buffers.normal.push(faceNormals[ i0 * 3 + 1 ]);
+        buffers.normal.push(faceNormals[ i0 * 3 + 2 ]);
+
+        buffers.normal.push(faceNormals[ i1 * 3 ]);
+        buffers.normal.push(faceNormals[ i1 * 3 + 1 ]);
+        buffers.normal.push(faceNormals[ i1 * 3 + 2 ]);
+
+        buffers.normal.push(faceNormals[ i2 * 3 ]);
+        buffers.normal.push(faceNormals[ i2 * 3 + 1 ]);
+        buffers.normal.push(faceNormals[ i2 * 3 + 2 ]);
+
+      }
+
+      if (geoInfo.uv) {
+        for (let j = 0; j < geoInfo.uv.length; j++) {
+          if (buffers.uvs[j] === undefined) {
+            buffers.uvs[j] = [];
+          }
+
+          buffers.uvs[j].push(faceUVs[j][i0 * 2]);
+          buffers.uvs[j].push(faceUVs[j][i0 * 2 + 1]);
+
+          buffers.uvs[j].push(faceUVs[j][i1 * 2]);
+          buffers.uvs[j].push(faceUVs[j][i1 * 2 + 1]);
+
+          buffers.uvs[j].push(faceUVs[j][i2 * 2]);
+          buffers.uvs[j].push(faceUVs[j][i2 * 2 + 1]);
+        }
+      }
+
+    }
+
+  }
+
+  addMorphTargets (parentGeo: BufferGeometry, parentGeoNode: FBXGeometryNode, morphTargets: FBXMorphTarget[], preTransform: Matrix4) {
+
+    if (morphTargets.length === 0) {return;}
+
+    parentGeo.morphTargetsRelative = true;
+
+    parentGeo.morphAttributes.position = [];
+    // parentGeo.morphAttributes.normal = []; // not implemented
+
+    const fbxTree = global.fbxTree;
+    const fbxGeometry = fbxTree.Objects?.Geometry;
+
+    if (!fbxGeometry) {
+      throw new Error('Objects.Geometry is not defined in FBXTree');
+    }
+
+    morphTargets.forEach(morphTarget=> {
+      const rawTargets = morphTarget.rawTargets;
+
+      if (!rawTargets) {
+        return;
+      }
+      rawTargets.forEach(rawTarget=> {
+
+        const morphGeoNode = fbxGeometry[ rawTarget.geoID ?? 0 ];
+
+        if (morphGeoNode !== undefined) {
+
+          this.genMorphGeometry(parentGeo, parentGeoNode, morphGeoNode, preTransform, rawTarget.name ?? '');
+
+        }
+
+      });
+
+    });
+
+  }
+
+  // a morph geometry node is similar to a standard  node, and the node is also contained
+  // in FBXTree.Objects.Geometry, however it can only have attributes for position, normal
+  // and a special attribute Index defining which vertices of the original geometry are affected
+  // Normal and position attributes only have data for the vertices that are affected by the morph
+  genMorphGeometry (parentGeo: BufferGeometry, parentGeoNode: FBXGeometryNode, morphGeoNode: FBXGeometryNode, preTransform: Matrix4, name: string) {
+    const basePositions = parentGeoNode.Vertices !== undefined ? parentGeoNode.Vertices.a : [];
+    const baseIndices = parentGeoNode.PolygonVertexIndex !== undefined ? parentGeoNode.PolygonVertexIndex.a : [];
+
+    const morphPositionsSparse = morphGeoNode.Vertices !== undefined ? morphGeoNode.Vertices.a : [];
+    const morphIndices = morphGeoNode.Indexes !== undefined ? morphGeoNode.Indexes.a : [];
+
+    const length = parentGeo.attributes.position.count * 3;
+    const morphPositions = new Float32Array(length);
+
+    for (let i = 0; i < morphIndices.length; i ++) {
+
+      const morphIndex = morphIndices[ i ] * 3;
+
+      morphPositions[ morphIndex ] = morphPositionsSparse[ i * 3 ];
+      morphPositions[ morphIndex + 1 ] = morphPositionsSparse[ i * 3 + 1 ];
+      morphPositions[ morphIndex + 2 ] = morphPositionsSparse[ i * 3 + 2 ];
+
+    }
+
+    // TODO: add morph normal support
+    const morphGeoInfo: GeoInfo = {
+      vertexIndices: baseIndices,
+      vertexPositions: Array.from(morphPositions),
+      baseVertexPositions: basePositions,
+    };
+
+    const morphBuffers = this.genBuffers(morphGeoInfo);
+
+    const positionAttribute = new Float32BufferAttribute(morphBuffers.vertex, 3);
+
+    positionAttribute.name = name || morphGeoNode.attrName;
+
+    positionAttribute.applyMatrix4(preTransform);
+
+    parentGeo.morphAttributes.position.push(positionAttribute);
+
+  }
+
+  // Parse normal from FBXTree.Objects.Geometry.LayerElementNormal if it exists
+  parseNormals (NormalNode: FBXLayerElementNormal) {
+
+    const mappingType = NormalNode.MappingInformationType;
+    const referenceType = NormalNode.ReferenceInformationType;
+    const buffer = NormalNode.Normals?.a || [];
+    let indexBuffer: number[] = [];
+
+    if (referenceType === 'IndexToDirect') {
+
+      if ('NormalIndex' in NormalNode) {
+
+        indexBuffer = NormalNode.NormalIndex?.a || [];
+
+      } else if ('NormalsIndex' in NormalNode) {
+
+        indexBuffer = NormalNode.NormalsIndex?.a || [];
+
+      }
+
+    }
+
+    return {
+      dataSize: 3,
+      buffer: buffer,
+      indices: indexBuffer,
+      mappingType: mappingType,
+      referenceType: referenceType,
+    };
+
+  }
+
+  // Parse UVs from FBXTree.Objects.Geometry.LayerElementUV if it exists
+  parseUVs (UVNode: FBXLayerElementUV): GeoBufferInfo {
+
+    const mappingType = UVNode.MappingInformationType;
+    const referenceType = UVNode.ReferenceInformationType;
+    const buffer = UVNode.UV.a;
+    let indexBuffer = [];
+
+    if (referenceType === 'IndexToDirect') {
+
+      indexBuffer = UVNode.UVIndex.a;
+
+    }
+
+    return {
+      dataSize: 2,
+      buffer: buffer,
+      indices: indexBuffer,
+      mappingType: mappingType,
+      referenceType: referenceType,
+    };
+
+  }
+
+  // Parse Vertex Colors from FBXTree.Objects.Geometry.LayerElementColor if it exists
+  parseVertexColors (ColorNode: FBXLayerElementColor): { dataSize: number, buffer: number[], indices: number[], mappingType: string, referenceType: string } {
+
+    const mappingType = ColorNode.MappingInformationType;
+    const referenceType = ColorNode.ReferenceInformationType;
+    const buffer = ColorNode.Colors.a;
+    let indexBuffer: number[] = [];
+
+    if (referenceType === 'IndexToDirect') {
+
+      indexBuffer = ColorNode.ColorIndex.a;
+
+    }
+
+    for (let i = 0, c = new Color(); i < buffer.length; i += 4) {
+
+      c.fromArray(buffer, i);
+      ColorManagement.toWorkingColorSpace(c, SRGBColorSpace);
+      c.toArray(buffer, i);
+
+    }
+
+    return {
+      dataSize: 4,
+      buffer: buffer,
+      indices: indexBuffer,
+      mappingType: mappingType,
+      referenceType: referenceType,
+    };
+
+  }
+
+  // Parse mapping and material data in FBXTree.Objects.Geometry.LayerElementMaterial if it exists
+  parseMaterialIndices (MaterialNode: FBXMaterialNode) {
+
+    const mappingType = MaterialNode.MappingInformationType;
+    const referenceType = MaterialNode.ReferenceInformationType;
+
+    if (mappingType === 'NoMappingInformation') {
+
+      return {
+        dataSize: 1,
+        buffer: [0],
+        indices: [0],
+        mappingType: 'AllSame',
+        referenceType: referenceType,
+      };
+
+    }
+
+    const materialIndexBuffer = MaterialNode.Materials.a;
+
+    // Since materials are stored as indices, there's a bit of a mismatch between FBX and what
+    // we expect.So we create an intermediate buffer that points to the index in the buffer,
+    // for conforming with the other functions we've written for other data.
+    const materialIndices = [];
+
+    for (let i = 0; i < materialIndexBuffer.length; ++ i) {
+
+      materialIndices.push(i);
+
+    }
+
+    return {
+      dataSize: 1,
+      buffer: materialIndexBuffer,
+      indices: materialIndices,
+      mappingType: mappingType,
+      referenceType: referenceType,
+    };
+
+  }
+
+  // Generate a NurbGeometry from a node in FBXTree.Objects.Geometry
+  parseNurbsGeometry (geoNode: FBXGeometryNode) {
+
+    const order = parseInt(geoNode.Order || '0');
+
+    if (isNaN(order)) {
+
+      console.error('THREE.FBXLoader: Invalid Order %s given for geometry ID: %s', geoNode.Order, geoNode.id);
+
+      return new BufferGeometry();
+
+    }
+
+    const degree = order - 1;
+    const knots = geoNode.KnotVector?.a || [];
+    const controlPoints: Vector4[] = [];
+    const pointsValues = geoNode.Points?.a || [];
+
+    for (let i = 0, l = pointsValues.length; i < l; i += 4) {
+
+      controlPoints.push(new Vector4().fromArray(pointsValues, i));
+
+    }
+
+    let startKnot, endKnot;
+
+    if (geoNode.Form === 'Closed') {
+
+      controlPoints.push(controlPoints[ 0 ]);
+
+    } else if (geoNode.Form === 'Periodic') {
+
+      startKnot = degree;
+      endKnot = knots.length - 1 - startKnot;
+
+      for (let i = 0; i < degree; ++ i) {
+
+        controlPoints.push(controlPoints[ i ]);
+
+      }
+
+    }
+
+    const curve = new NURBSCurve(degree, knots, controlPoints, startKnot, endKnot);
+    const points = curve.getPoints(controlPoints.length * 12);
+
+    return new BufferGeometry().setFromPoints(points);
+
+  }
+
+}

--- a/src/parse/FBX-tree-parser.ts
+++ b/src/parse/FBX-tree-parser.ts
@@ -1,0 +1,1658 @@
+import type { TextureLoader, LoadingManager, EulerOrder, BufferGeometry, MeshStandardMaterialParameters } from 'three';
+import { MeshStandardMaterial, RepeatWrapping, ClampToEdgeWrapping, Skeleton, Texture, MeshPhongMaterial, ColorManagement, Color, SRGBColorSpace, EquirectangularReflectionMapping, Matrix4, Group, Bone, PropertyBinding, Object3D, PerspectiveCamera, PointLight, DirectionalLight, MathUtils, SpotLight, Loader, SkinnedMesh, Mesh, LineBasicMaterial, Line, Vector3, AmbientLight, MeshPhysicalMaterial } from 'three';
+import type { FBXConnectionNode, FBXConnectionReference, FBXMorphTarget, FBXLightNodeAttribute, FBXMaterialNode, FBXMeshNode, FBXModelNode, FBXSkeleton, FBXTextureNode, FBXVideoNode, IFBXPropertyValue, RawBone, UserDataTransform, FBXRawTargets } from '../constants';
+import { global } from '../constants';
+import { AnimationParser } from './FBX-animation-parser';
+import { GeometryParser } from './FBX-geometry-parser';
+import { generateTransform, getEulerOrder } from './utils';
+
+interface FBXMeshStandardMaterialParameters extends MeshStandardMaterialParameters {
+  reflectivity?: number,
+  specularMap?: Texture,
+
+}
+
+// Parse the FBXTree object returned by the BinaryParser or TextParser and return a Group
+export class FBXTreeParser {
+  textureLoader: TextureLoader;
+  manager: LoadingManager;
+
+  constructor (textureLoader: TextureLoader, manager: LoadingManager) {
+
+    this.textureLoader = textureLoader;
+    this.manager = manager;
+
+  }
+
+  parse () {
+
+    global.connections = this.parseConnections();
+
+    const images = this.parseImages();
+    const textures = this.parseTextures(images);
+    const materials = this.parseMaterials(textures);
+    const deformers = this.parseDeformers();
+    const geometryMap = new GeometryParser().parse(deformers);
+
+    this.parseScene(deformers, geometryMap, materials);
+
+    return global.sceneGraph;
+
+  }
+
+  // Parses global.fbxTree.Connections which holds parent-child connections between objects (e.g. material -> texture, model->geometry )
+  // and details the connection type
+  parseConnections () {
+
+    const connectionMap = new Map();
+
+    const fbxTree = global.fbxTree;
+
+    if ('Connections' in fbxTree) {
+      if (!fbxTree.Connections) {
+        throw new Error('FBXLoader');
+      }
+      const rawConnections = fbxTree.Connections.connections;
+
+      rawConnections.forEach(rawConnection =>{
+
+        const fromID = rawConnection[ 0 ];
+        const toID = rawConnection[ 1 ];
+        const relationship = rawConnection[ 2 ];
+
+        if (! connectionMap.has(fromID)) {
+
+          connectionMap.set(fromID, {
+            parents: [],
+            children: [],
+          });
+
+        }
+
+        const parentRelationship = { ID: toID, relationship: relationship };
+
+        connectionMap.get(fromID).parents.push(parentRelationship);
+
+        if (! connectionMap.has(toID)) {
+
+          connectionMap.set(toID, {
+            parents: [],
+            children: [],
+          });
+
+        }
+
+        const childRelationship = { ID: fromID, relationship: relationship };
+
+        connectionMap.get(toID).children.push(childRelationship);
+
+      });
+
+    }
+
+    return connectionMap;
+
+  }
+
+  // Parse global.fbxTree.Objects.Video for embedded image data
+  // These images are connected to textures in global.fbxTree.Objects.Textures
+  // via global.fbxTree.Connections.
+  parseImages () {
+
+    const images: Record<number, string> = {};
+    const blobs: Record<string, string | undefined> = {};
+
+    if (!global.fbxTree.Objects) {
+      throw new Error('FBXTree.Objects is undefined');
+    }
+
+    if ('Video' in global.fbxTree.Objects) {
+
+      const videoNodes = global.fbxTree.Objects.Video;
+
+      for (const nodeID in videoNodes) {
+
+        const videoNode = videoNodes[ nodeID ];
+
+        const id = parseInt(nodeID);
+
+        images[ id ] = videoNode.RelativeFilename || videoNode.Filename;
+
+        // raw image data is in videoNode.Content
+        if ('Content' in videoNode) {
+
+          const arrayBufferContent = (videoNode.Content instanceof ArrayBuffer) && (videoNode.Content.byteLength > 0);
+          const base64Content = (typeof videoNode.Content === 'string') && (videoNode.Content !== '');
+
+          if (arrayBufferContent || base64Content) {
+
+            const image = this.parseImage(videoNodes[ nodeID ]);
+
+            blobs[ videoNode.RelativeFilename || videoNode.Filename ] = image;
+
+          }
+
+        }
+
+      }
+
+    }
+
+    for (const id in images) {
+
+      const filename = images[ id ];
+
+      if (blobs[ filename ] !== undefined) {
+        images[ id ] = blobs[ filename ];
+      } else {
+        images[ id ] = images[ id ]?.split('\\').pop() || images[ id ];
+      }
+
+    }
+
+    return images;
+
+  }
+
+  // Parse embedded image data in global.fbxTree.Video.Content
+  parseImage (videoNode: FBXVideoNode) {
+
+    const content = videoNode.Content;
+    const fileName = videoNode.RelativeFilename || videoNode.Filename;
+    const extension = fileName.slice(fileName.lastIndexOf('.') + 1).toLowerCase();
+
+    let type;
+
+    switch (extension) {
+
+      case 'bmp':
+
+        type = 'image/bmp';
+
+        break;
+      case 'jpg':
+      case 'jpeg':
+
+        type = 'image/jpeg';
+
+        break;
+      case 'png':
+
+        type = 'image/png';
+
+        break;
+      case 'webp':
+
+        type = 'image/webp';
+
+        break;
+      case 'tif':
+
+        type = 'image/tiff';
+
+        break;
+      case 'tga':
+
+        if (this.manager.getHandler('.tga') === null) {
+
+          console.warn('FBXLoader: TGA loader not found, skipping ', fileName);
+
+        }
+
+        type = 'image/tga';
+
+        break;
+      default:
+
+        console.warn('FBXLoader: Image type "' + extension + '" is not supported.');
+
+        return;
+
+    }
+
+    if (typeof content === 'string') { // ASCII format
+
+      return 'data:' + type + ';base64,' + content;
+
+    } else { // Binary Format
+
+      const array = new Uint8Array(content);
+
+      return window.URL.createObjectURL(new Blob([array], { type: type }));
+
+    }
+
+  }
+
+  // Parse nodes in global.fbxTree.Objects.Texture
+  // These contain details such as UV scaling, cropping, rotation etc and are connected
+  // to images in global.fbxTree.Objects.Video
+  parseTextures (images: Record<string, string>) {
+
+    const textureMap = new Map();
+
+    if (!global.fbxTree.Objects) {
+      throw new Error('FBXTree Objects is undefined');
+    }
+
+    if ('Texture' in global.fbxTree.Objects) {
+
+      const textureNodes = global.fbxTree.Objects.Texture;
+
+      for (const nodeID in textureNodes) {
+
+        const texture = this.parseTexture(textureNodes[ nodeID ], images);
+
+        textureMap.set(parseInt(nodeID), texture);
+
+      }
+
+    }
+
+    return textureMap;
+
+  }
+
+  // Parse individual node in global.fbxTree.Objects.Texture
+  parseTexture (textureNode: FBXTextureNode, images: Record<string, string>) {
+
+    const texture = this.loadTexture(textureNode, images);
+
+    (texture as any).ID = textureNode.id;
+
+    texture.name = textureNode.attrName;
+
+    const wrapModeU = textureNode.WrapModeU;
+    const wrapModeV = textureNode.WrapModeV;
+
+    const valueU = wrapModeU !== undefined ? wrapModeU.value : 0;
+    const valueV = wrapModeV !== undefined ? wrapModeV.value : 0;
+
+    // http://download.autodesk.com/us/fbx/SDKdocs/FBX_SDK_Help/files/fbxsdkref/class_k_fbx_texture.html#889640e63e2e681259ea81061b85143a
+    // 0: repeat(default), 1: clamp
+
+    texture.wrapS = valueU === 0 ? RepeatWrapping : ClampToEdgeWrapping;
+    texture.wrapT = valueV === 0 ? RepeatWrapping : ClampToEdgeWrapping;
+
+    if ('Scaling' in textureNode) {
+
+      const values = textureNode.Scaling.value;
+
+      texture.repeat.x = values[ 0 ];
+      texture.repeat.y = values[ 1 ];
+
+    }
+
+    if ('Translation' in textureNode) {
+
+      const values = textureNode.Translation.value;
+
+      texture.offset.x = values[ 0 ];
+      texture.offset.y = values[ 1 ];
+
+    }
+
+    return texture;
+
+  }
+
+  // load a texture specified as a blob or data URI, or via an external URL using TextureLoader
+  loadTexture (textureNode: FBXTextureNode, images: Record<string, string>): Texture {
+
+    const extension = (textureNode.FileName.split('.').pop() || '').toLowerCase();
+
+    let loader = this.manager.getHandler(`.${extension}`);
+
+    if (loader === null) {loader = this.textureLoader;}
+
+    const loaderPath = loader.path;
+
+    if (! loaderPath) {
+
+      loader.setPath(this.textureLoader.path);
+
+    }
+    const connections = global.connections;
+
+    if (!connections) {
+      throw new Error('Global connections are undefined');
+
+    }
+    const children = connections.get(textureNode.id)?.children;
+
+    let fileName;
+
+    if (children !== undefined && children.length > 0 && images[ children[ 0 ].ID ] !== undefined) {
+
+      fileName = images[ children[ 0 ].ID ];
+
+      if (fileName.indexOf('blob:') === 0 || fileName.indexOf('data:') === 0) {
+
+        loader.setPath('');
+
+      }
+
+    }
+
+    if (fileName === undefined) {
+
+      console.warn('FBXLoader: Undefined filename, creating placeholder texture.');
+
+      return new Texture();
+
+    }
+
+    const texture = (loader as TextureLoader).load(fileName, () => { });
+
+    // revert to initial path
+    loader.setPath(loaderPath);
+
+    return texture;
+
+  }
+
+  // Parse nodes in global.fbxTree.Objects.Material
+  parseMaterials (textureMap: Map<number, Texture>) {
+
+    const materialMap = new Map();
+    const fbxTree = global.fbxTree;
+
+    if (!fbxTree || !fbxTree.Objects) {
+      throw new Error('Global FBXTree or fbxTree.Objects is undefined');
+
+    }
+
+    if ('Material' in fbxTree.Objects) {
+
+      const materialNodes = fbxTree.Objects.Material;
+
+      for (const nodeID in materialNodes) {
+
+        const material = this.parseMaterial(materialNodes[ nodeID ], textureMap);
+
+        if (material !== null) {materialMap.set(parseInt(nodeID), material);}
+
+      }
+
+    } else {
+      console.warn('FBXLoader: No materials found in the FBX tree.');
+    }
+
+    return materialMap;
+
+  }
+
+  // Parse single node in global.fbxTree.Objects.Material
+  // Materials are connected to texture maps in global.fbxTree.Objects.Textures
+  // FBX format currently only supports Lambert and Phong shading models
+  parseMaterial (materialNode: FBXMaterialNode, textureMap: Map<number, Texture>) {
+
+    const ID = materialNode.id;
+    const name = materialNode.attrName;
+    let type: string | IFBXPropertyValue<string> = materialNode.ShadingModel;
+
+    // Case where FBX wraps shading model in property object.
+    if (typeof type === 'object') {
+
+      type = type.value;
+
+    }
+
+    // Ignore unused materials which don't have any connections.
+    if (! global.connections.has(ID)) {return null;}
+
+    const parameters = this.parseParameters(materialNode, textureMap, ID);
+
+    let material;
+
+    switch (type.toLowerCase()) {
+
+      case 'phong':
+        material = new MeshStandardMaterial();
+
+        break;
+      case 'lambert':
+        material = new MeshPhysicalMaterial();
+
+        break;
+      default:
+        console.warn('THREE.FBXLoader: unknown material type "%s". Defaulting to MeshPhongMaterial.', type);
+        material = new MeshStandardMaterial();
+
+        break;
+
+    }
+
+    material.setValues(parameters);
+    material.name = name;
+
+    return material;
+
+  }
+
+  // Parse FBX material and return parameters suitable for a three.js material
+  // Also parse the texture map and return any textures associated with the material
+  parseParameters (materialNode: FBXMaterialNode, textureMap: Map<number, Texture>, ID: number) {
+
+    const parameters: FBXMeshStandardMaterialParameters = {};
+    const connections = global.connections;
+
+    if (!connections) {
+      throw new Error('Global connections is undefined');
+    }
+
+    if (materialNode.BumpFactor) {
+
+      parameters.bumpScale = materialNode.BumpFactor.value;
+
+    }
+
+    if (materialNode.Diffuse) {
+
+      parameters.color = ColorManagement.toWorkingColorSpace(new Color().fromArray(materialNode.Diffuse.value), SRGBColorSpace);
+
+    } else if (materialNode.DiffuseColor && (materialNode.DiffuseColor.type === 'Color' || materialNode.DiffuseColor.type === 'ColorRGB')) {
+
+      // The blender exporter exports diffuse here instead of in materialNode.Diffuse
+      parameters.color = ColorManagement.toWorkingColorSpace(new Color().fromArray(materialNode.DiffuseColor.value), SRGBColorSpace);
+
+    }
+
+    if (materialNode.DisplacementFactor) {
+
+      parameters.displacementScale = materialNode.DisplacementFactor.value as number;
+
+    }
+
+    if (materialNode.Emissive) {
+
+      parameters.emissive = ColorManagement.toWorkingColorSpace(new Color().fromArray(materialNode.Emissive.value), SRGBColorSpace);
+
+    } else if (materialNode.EmissiveColor && (materialNode.EmissiveColor.type === 'Color' || materialNode.EmissiveColor.type === 'ColorRGB')) {
+
+      // The blender exporter exports emissive color here instead of in materialNode.Emissive
+      parameters.emissive = ColorManagement.toWorkingColorSpace(new Color().fromArray(materialNode.EmissiveColor.value), SRGBColorSpace);
+
+    }
+
+    if (materialNode.EmissiveFactor) {
+
+      parameters.emissiveIntensity = parseFloat(materialNode.EmissiveFactor.value);
+
+    }
+
+    // the transparency handling is implemented based on Blender/Unity's approach: https://github.com/sobotka/blender-addons/blob/7d80f2f97161fc8e353a657b179b9aa1f8e5280b/io_scene_fbx/import_fbx.py#L1444-L1459
+
+    parameters.opacity = 1 - (materialNode.TransparencyFactor ? parseFloat(materialNode.TransparencyFactor.value) : 0);
+
+    if (parameters.opacity === 1 || parameters.opacity === 0) {
+
+      parameters.opacity = (materialNode.Opacity ? parseFloat(materialNode.Opacity.value) : 1);
+
+      if (parameters.opacity === null) {
+
+        parameters.opacity = 1 - (materialNode.TransparentColor ? parseFloat(materialNode.TransparentColor.value[ 0 ]) : 0);
+
+      }
+
+    }
+
+    if (parameters.opacity < 1.0) {
+
+      parameters.transparent = true;
+
+    }
+
+    if (materialNode.ReflectionFactor) {
+
+      parameters.reflectivity = materialNode.ReflectionFactor.value;
+
+    }
+
+    if (materialNode.Shininess) {
+
+      parameters.roughness = 1 / materialNode.Shininess.value;
+
+    }
+
+    if (materialNode.Specular) {
+      // 将specular颜色转换为metalness值
+      // 可以使用颜色的平均值或亮度作为金属度
+      const specularColor = new Color().fromArray(materialNode.Specular.value);
+
+      // 使用RGB平均值作为金属度
+      parameters.metalness = (specularColor.r + specularColor.g + specularColor.b) / 3;
+      // 限制metalness在0-1范围内
+      parameters.metalness = Math.max(0, Math.min(1, parameters.metalness));
+
+    } else if (materialNode.SpecularColor && materialNode.SpecularColor.type === 'Color') {
+
+      // The blender exporter exports specular color here instead of in materialNode.Specular
+      const specularColor = new Color().fromArray(materialNode.SpecularColor.value);
+
+      // 使用RGB平均值作为金属度
+      parameters.metalness = (specularColor.r + specularColor.g + specularColor.b) / 3;
+      // 限制metalness在0-1范围内
+      parameters.metalness = Math.max(0, Math.min(1, parameters.metalness));
+    }
+
+    connections.get(ID)?.children.forEach(child => {
+      if (!(typeof child.ID === 'number')) {
+        throw new Error('THREE.FBXLoader: Invalid child ID type');
+      }
+      const type = child.relationship;
+
+      switch (type) {
+
+        case 'Bump':
+          parameters.bumpMap = this.getTexture(textureMap, child.ID);
+
+          break;
+        case 'ShininessExponent':
+          parameters.roughnessMap = this.getTexture(textureMap, child.ID);
+
+          break;
+        case 'ReflectionFactor':
+          parameters.metalnessMap = this.getTexture(textureMap, child.ID);
+
+          break;
+        case 'Maya|TEX_ao_map':
+          parameters.aoMap = this.getTexture(textureMap, child.ID);
+
+          break;
+        case 'DiffuseColor':
+        case 'Maya|TEX_color_map':
+          parameters.map = this.getTexture(textureMap, child.ID);
+          if (parameters.map !== undefined) {
+
+            parameters.map.colorSpace = SRGBColorSpace;
+
+          }
+
+          break;
+        case 'DisplacementColor':
+          parameters.displacementMap = this.getTexture(textureMap, child.ID);
+
+          break;
+        case 'EmissiveColor':
+          parameters.emissiveMap = this.getTexture(textureMap, child.ID);
+          if (parameters.emissiveMap !== undefined) {
+
+            parameters.emissiveMap.colorSpace = SRGBColorSpace;
+
+          }
+
+          break;
+        case 'NormalMap':
+        case 'Maya|TEX_normal_map':
+          parameters.normalMap = this.getTexture(textureMap, child.ID);
+
+          break;
+        case 'ReflectionColor':
+          parameters.envMap = this.getTexture(textureMap, child.ID);
+          if (parameters.envMap !== undefined) {
+
+            parameters.envMap.mapping = EquirectangularReflectionMapping;
+            parameters.envMap.colorSpace = SRGBColorSpace;
+
+          }
+
+          break;
+        case 'SpecularColor':
+          parameters.specularMap = this.getTexture(textureMap, child.ID);
+          if (parameters.specularMap !== undefined) {
+
+            parameters.specularMap.colorSpace = SRGBColorSpace;
+
+          }
+          if (parameters.specularMap !== undefined) {
+
+            parameters.specularMap.colorSpace = SRGBColorSpace;
+
+          }
+
+          break;
+        case 'TransparentColor':
+        case 'TransparencyFactor':
+          parameters.alphaMap = this.getTexture(textureMap, child.ID);
+          parameters.transparent = true;
+
+          break;
+        case 'AmbientColor':
+        case 'SpecularFactor': // AKA specularLevel
+        case 'VectorDisplacementColor': // NOTE: Seems to be a copy of DisplacementColor
+        default:
+          console.warn('THREE.FBXLoader: %s map is not supported in three.js, skipping texture.', type);
+
+          break;
+
+      }
+
+    });
+
+    return parameters;
+
+  }
+
+  // get a texture from the textureMap for use by a material.
+  getTexture (textureMap: Map<number, Texture>, id: number) {
+    const objects = global.fbxTree.Objects;
+    const connections = global.connections;
+    let textureID: number | undefined = id;
+
+    if (!objects || !connections) {
+      throw new Error('No objects found in fbxTree.');
+    }
+    // if the texture is a layered texture, just use the first layer and issue a warning
+    if ('LayeredTexture' in objects && id in objects.LayeredTexture) {
+
+      console.warn('THREE.FBXLoader: layered textures are not supported in three.js. Discarding all but first layer.');
+      textureID = connections.get(id)?.children[ 0 ].ID;
+
+    }
+
+    if (!textureID) {
+      throw new Error('THREE.FBXLoader: No valid texture ID found.');
+    }
+
+    return textureMap.get(textureID);
+
+  }
+
+  // Parse nodes in global.fbxTree.Objects.Deformer
+  // Deformer node can contain skinning or Vertex Cache animation data, however only skinning is supported here
+  // Generates map of Skeleton-like objects for use later when generating and binding skeletons.
+  parseDeformers () {
+
+    const skeletons: Record<string, FBXSkeleton> = {};
+    const morphTargets: Record<string, FBXMorphTarget> = {};
+    const objects = global.fbxTree.Objects;
+
+    if (!objects) {
+      throw new Error('No objects found in fbxTree.');
+    }
+    if ('Deformer' in objects) {
+
+      const DeformerNodes = objects.Deformer;
+
+      for (const nodeID in DeformerNodes) {
+
+        const deformerNode = DeformerNodes[ nodeID ];
+
+        const relationships = global.connections.get(parseInt(nodeID));
+
+        if (!relationships) {
+          throw new Error('No relationships found for nodeID: ' + nodeID);
+        }
+
+        if (deformerNode.attrType === 'Skin') {
+
+          const skeleton = this.parseSkeleton(relationships, DeformerNodes);
+
+          skeleton.ID = nodeID;
+
+          if (relationships.parents.length > 1) {console.warn('THREE.FBXLoader: skeleton attached to more than one geometry is not supported.');}
+          skeleton.geometryID = relationships.parents[ 0 ].ID;
+
+          skeletons[ nodeID ] = skeleton;
+
+        } else if (deformerNode.attrType === 'BlendShape') {
+
+          const morphTarget: FBXMorphTarget = {
+            id: nodeID,
+            rawTargets: undefined,
+            skeleton:   undefined,
+          };
+
+          morphTarget.rawTargets = this.parseMorphTargets(relationships, DeformerNodes);
+          morphTarget.id = nodeID;
+
+          if (relationships.parents.length > 1) {console.warn('THREE.FBXLoader: morph target attached to more than one geometry is not supported.');}
+
+          morphTargets[ nodeID ] = morphTarget;
+
+        }
+
+      }
+
+    }
+
+    return {
+
+      skeletons: skeletons,
+      morphTargets: morphTargets,
+
+    };
+
+  }
+
+  // Parse single nodes in global.fbxTree.Objects.Deformer
+  // The top level skeleton node has type 'Skin' and sub nodes have type 'Cluster'
+  // Each skin node represents a skeleton and each cluster node represents a bone
+  parseSkeleton (relationships: FBXConnectionNode, deformerNodes: Record<number, FBXMeshNode>): FBXSkeleton {
+
+    const rawBones: RawBone[] = [];
+
+    relationships.children.forEach(function (child) {
+
+      const boneNode = deformerNodes[ child.ID ];
+
+      if (!boneNode || !boneNode.TransformLink) {
+        throw new Error('THREE.FBXLoader: No bone node found for child ID: ' + child.ID);
+      }
+
+      if (boneNode.attrType !== 'Cluster') {return;}
+
+      const rawBone: RawBone = {
+
+        ID: child.ID,
+        indices: [],
+        weights: [],
+        transformLink: new Matrix4().fromArray(boneNode.TransformLink.a),
+        // transform: new Matrix4().fromArray( boneNode.Transform.a ),
+        // linkMode: boneNode.Mode,
+
+      };
+
+      if (boneNode.Indexes && boneNode.Weights) {
+
+        rawBone.indices = boneNode.Indexes.a;
+        rawBone.weights = boneNode.Weights.a;
+
+      }
+
+      rawBones.push(rawBone);
+
+    });
+
+    return {
+      ID: '',
+      rawBones: rawBones,
+      bones: [],
+      geometryID: 0,
+    };
+
+  }
+
+  // The top level morph deformer node has type "BlendShape" and sub nodes have type "BlendShapeChannel"
+  parseMorphTargets (relationships: FBXConnectionNode, deformerNodes: Record<number, FBXMeshNode>): FBXRawTargets[] | undefined {
+
+    const rawMorphTargets: FBXRawTargets[] = [];
+    const connections = global.connections;
+
+    if (!connections) {
+      throw new Error('Global connections is undefined');
+    }
+
+    for (let i = 0; i < relationships.children.length; i ++) {
+
+      const child = relationships.children[ i ];
+
+      const morphTargetNode = deformerNodes[ child.ID ];
+
+      const rawMorphTarget: FBXRawTargets = {
+        geoID: 0,
+        name: morphTargetNode.attrName,
+        initialWeight: morphTargetNode.DeformPercent,
+        id: morphTargetNode.id,
+        fullWeights: morphTargetNode.FullWeights.a,
+
+      };
+
+      if (morphTargetNode.attrType !== 'BlendShapeChannel') {return;}
+      let id = child.ID;
+
+      if (typeof child.ID !== 'number') {
+        id = parseInt(child.ID);
+      }
+      rawMorphTarget.geoID = connections.get(id)?.children.filter((child: FBXConnectionReference) => {
+
+        return child.relationship === undefined;
+
+      })[ 0 ]?.ID || 0;
+
+      rawMorphTargets.push(rawMorphTarget);
+
+    }
+
+    return rawMorphTargets;
+
+  }
+
+  // create the main Group() to be returned by the loader
+  parseScene (deformers: {
+    skeletons: Record<string, FBXSkeleton>,
+    morphTargets: Record<string, FBXMorphTarget>,
+  }, geometryMap: Map<number, BufferGeometry >, materialMap: Map<number, MeshPhongMaterial | MeshStandardMaterial | LineBasicMaterial>) {
+    global.sceneGraph = new Group();
+    const fbxTree = global.fbxTree;
+    const connections = global.connections;
+
+    if (!fbxTree || !fbxTree.Objects || !connections) {
+      throw new Error('Global FBXTree or fbxTree.Objects or global connections is undefined');
+    }
+
+    const modelMap = this.parseModels(deformers.skeletons, geometryMap, materialMap);
+
+    const modelNodes = fbxTree.Objects.Model;
+
+    if (!modelNodes) {
+      throw new Error('Model nodes are undefined');
+    }
+    modelMap.forEach(model => {
+      const modelID = (model as any).ID;
+      const modelNode = modelNodes[ modelID as string ];
+
+      this.setLookAtProperties(model, modelNode);
+
+      const parentConnections = connections.get(modelID)?.parents || [];
+
+      parentConnections.forEach(function (connection) {
+
+        const parent = modelMap.get(connection.ID);
+
+        if (parent !== undefined) {parent.add(model);}
+
+      });
+
+      if (model.parent === null) {
+
+        global.sceneGraph.add(model);
+
+      }
+
+    });
+
+    this.bindSkeleton(deformers.skeletons, geometryMap, modelMap);
+
+    this.addGlobalSceneSettings();
+
+    global.sceneGraph.traverse(function (node) {
+
+      if (node.userData.transformData) {
+
+        if (node.parent) {
+
+          node.userData.transformData.parentMatrix = node.parent.matrix;
+          node.userData.transformData.parentMatrixWorld = node.parent.matrixWorld;
+
+        }
+
+        const transform = generateTransform(node.userData.transformData);
+
+        node.applyMatrix4(transform);
+        node.updateWorldMatrix(true, true);
+
+      }
+
+    });
+
+    const animations = new AnimationParser().parse();
+
+    // if all the models where already combined in a single group, just return that
+    if (global.sceneGraph.children.length === 1 && (global.sceneGraph.children[ 0 ] as Group).isGroup) {
+
+      global.sceneGraph.children[ 0 ].animations = animations;
+      global.sceneGraph = global.sceneGraph.children[ 0 ] as Group;
+
+    }
+
+    global.sceneGraph.animations = animations;
+
+  }
+
+  // parse nodes in global.fbxTree.Objects.Model
+  parseModels (skeletons: Record<string, FBXSkeleton>, geometryMap: Map<number, BufferGeometry>, materialMap: Map<number, MeshPhongMaterial | MeshStandardMaterial | LineBasicMaterial>) {
+
+    const modelMap: Map<number, Object3D> = new Map();
+    const fbxTree = global.fbxTree;
+    const connections = global.connections;
+
+    if (!fbxTree || !fbxTree.Objects || !connections) {
+      throw new Error('Global FBXTree or fbxTree.Objects or global connections is undefined');
+    }
+    const modelNodes = fbxTree.Objects.Model;
+
+    for (const nodeID in modelNodes) {
+
+      const id = parseInt(nodeID);
+      const node = modelNodes[ nodeID ];
+      const relationships = connections.get(id) || { parents: [], children: [] };
+
+      let model: Object3D | null = this.buildSkeleton(relationships, skeletons, id, node.attrName);
+
+      if (!model) {
+
+        switch (node.attrType) {
+
+          case 'Camera':
+            model = this.createCamera(relationships);
+
+            break;
+          case 'Light':
+            model = this.createLight(relationships);
+
+            break;
+          case 'Mesh':
+            model = this.createMesh(relationships, geometryMap, materialMap);
+
+            break;
+          case 'NurbsCurve':
+            model = this.createCurve(relationships, geometryMap);
+
+            break;
+          case 'LimbNode':
+          case 'Root':
+            model = new Bone();
+
+            break;
+          case 'Null':
+          default:
+            model = new Group();
+
+            break;
+
+        }
+
+        model.name = node.attrName ? PropertyBinding.sanitizeNodeName(node.attrName) : '';
+        model.userData.originalName = node.attrName;
+
+        (model as any).ID = id;
+
+      }
+
+      if (model === null) {
+        throw new Error('THREE.FBXLoader: Model is null');
+      }
+      this.getTransformData(model, node);
+      modelMap.set(id, model);
+
+    }
+
+    return modelMap;
+
+  }
+
+  buildSkeleton (relationships: FBXConnectionNode, skeletons: Record<string, FBXSkeleton>, id: number, name: string) {
+
+    let bone: Bone | null = null;
+    const buildSkeletons = skeletons;
+
+    relationships.parents.forEach(parent => {
+
+      Object.entries(buildSkeletons).forEach(([ID, skeleton]) => {
+
+        skeleton.rawBones.forEach((rawBone, i) => {
+
+          if (rawBone.ID === parent.ID) {
+
+            const subBone = bone;
+
+            bone = new Bone();
+
+            bone.matrixWorld.copy(rawBone.transformLink);
+
+            // set name and id here - otherwise in cases where "subBone" is created it will not have a name / id
+
+            bone.name = name ? PropertyBinding.sanitizeNodeName(name) : '';
+            bone.userData.originalName = name;
+            (bone as any).ID = id;
+
+            skeleton.bones[ i ] = bone;
+
+            // In cases where a bone is shared between multiple meshes
+            // duplicate the bone here and add it as a child of the first bone
+            if (subBone !== null) {
+
+              bone.add(subBone);
+
+            }
+
+          }
+
+        });
+
+      });
+
+    });
+
+    return bone;
+
+  }
+
+  // create a PerspectiveCamera or OrthographicCamera
+  createCamera (relationships: FBXConnectionNode) {
+    const fbxTree = global.fbxTree;
+    let model;
+    let cameraAttribute: FBXLightNodeAttribute | undefined;
+
+    if (!fbxTree || !fbxTree.Objects) {
+      throw new Error('Global FBXTree or fbxTree.Objects is undefined');
+    }
+
+    relationships.children.forEach(function (child) {
+      const nodeAttribute = fbxTree.Objects?.NodeAttribute;
+
+      if (!nodeAttribute) {
+        throw new Error('NodeAttribute is undefined');
+      }
+
+      const attr = nodeAttribute[ child.ID ];
+
+      if (attr !== undefined) {
+
+        cameraAttribute = attr;
+
+      }
+
+    });
+
+    if (!cameraAttribute) {
+
+      model = new Object3D();
+
+    } else {
+
+      let type = 0;
+
+      if (cameraAttribute.CameraProjectionType !== undefined && cameraAttribute.CameraProjectionType.value === 1) {
+
+        type = 1;
+
+      }
+
+      let nearClippingPlane = 1;
+
+      if (cameraAttribute.NearPlane !== undefined) {
+        const nearPlane = cameraAttribute.NearPlane.value;
+
+        if (typeof nearPlane !== 'number') {
+          throw new Error('THREE.FBXLoader: Invalid near plane value');
+        }
+
+        nearClippingPlane = nearPlane / 1000;
+
+      }
+
+      let farClippingPlane = 1000;
+
+      if (cameraAttribute.FarPlane !== undefined) {
+        const farPlane = cameraAttribute.FarPlane.value;
+
+        if (typeof farPlane !== 'number') {
+          throw new Error('THREE.FBXLoader: Invalid far plane value');
+        }
+        // FBX stores the far plane in millimeters
+
+        farClippingPlane = farPlane / 1000;
+
+      }
+
+      let width = window.innerWidth;
+      let height = window.innerHeight;
+
+      if (cameraAttribute.AspectWidth !== undefined && cameraAttribute.AspectHeight !== undefined) {
+        const aspectWidth = cameraAttribute.AspectWidth.value;
+        const aspectHeight = cameraAttribute.AspectHeight.value;
+
+        if (typeof aspectWidth !== 'number' || typeof aspectHeight !== 'number') {
+          throw new Error('THREE.FBXLoader: Invalid aspect width or height value');
+        }
+        width = aspectWidth;
+        height = aspectHeight;
+
+      }
+
+      const aspect = width / height;
+
+      let fov = 45;
+
+      if (cameraAttribute.FieldOfView !== undefined) {
+        const fieldOfView = cameraAttribute.FieldOfView.value;
+
+        if (typeof fieldOfView !== 'number') {
+          throw new Error('THREE.FBXLoader: Invalid field of view value');
+        }
+        // FBX stores the field of view in radians
+        fov = fieldOfView;
+
+      }
+
+      const focalLength = cameraAttribute.FocalLength ? cameraAttribute.FocalLength.value : null;
+
+      if (typeof focalLength !== 'number' && focalLength !== null) {
+        throw new Error('THREE.FBXLoader: Invalid focal length value');
+      }
+      switch (type) {
+
+        case 0: // Perspective
+          model = new PerspectiveCamera(fov, aspect, nearClippingPlane, farClippingPlane);
+          if (focalLength !== null) {model.setFocalLength(focalLength);}
+
+          break;
+        case 1: // Orthographic
+          console.warn('THREE.FBXLoader: Orthographic cameras not supported yet.');
+          model = new Object3D();
+
+          break;
+        default:
+          console.warn('THREE.FBXLoader: Unknown camera type ' + type + '.');
+          model = new Object3D();
+
+          break;
+
+      }
+
+    }
+
+    return model;
+
+  }
+
+  // Create a DirectionalLight, PointLight or SpotLight
+  createLight (relationships: FBXConnectionNode) {
+    const fbxTree = global.fbxTree;
+
+    if (!fbxTree || !fbxTree.Objects) {
+      throw new Error('Global FBXTree or fbxTree.Objects is undefined');
+    }
+    let model;
+    let lightAttribute: FBXLightNodeAttribute | undefined;
+
+    const nodeAttribute = fbxTree.Objects.NodeAttribute;
+
+    if (!nodeAttribute) {
+      throw new Error('NodeAttribute is undefined');
+    }
+    relationships.children.forEach(function (child) {
+
+      const attr = nodeAttribute[ child.ID ];
+
+      if (attr !== undefined) {
+
+        lightAttribute = attr;
+
+      }
+
+    });
+
+    if (lightAttribute === undefined) {
+
+      model = new Object3D();
+
+    } else {
+
+      let type;
+
+      // LightType can be undefined for Point lights
+      if (lightAttribute.LightType === undefined) {
+
+        type = 0;
+
+      } else {
+
+        type = lightAttribute.LightType.value;
+
+      }
+
+      let color: Color = new Color(0xffffff);
+
+      if (lightAttribute.Color !== undefined) {
+        if (typeof lightAttribute.Color.value !== 'object') {
+          throw new Error('THREE.FBXLoader: Invalid light color value');
+        }
+
+        color = ColorManagement.toWorkingColorSpace(new Color().fromArray(lightAttribute.Color.value), SRGBColorSpace);
+
+      }
+
+      if (typeof lightAttribute.Intensity?.value !== 'number') {
+        throw new Error('THREE.FBXLoader: Invalid light intensity value');
+      }
+      let intensity = (lightAttribute.Intensity === undefined) ? 1 : lightAttribute.Intensity.value / 100;
+
+      // light disabled
+      if (lightAttribute.CastLightOnObject !== undefined && lightAttribute.CastLightOnObject.value === 0) {
+
+        intensity = 0;
+
+      }
+
+      let distance = 0;
+
+      if (lightAttribute.FarAttenuationEnd !== undefined) {
+
+        if (lightAttribute.EnableFarAttenuation !== undefined && lightAttribute.EnableFarAttenuation.value === 0) {
+
+          distance = 0;
+
+        } else {
+          if (typeof lightAttribute.FarAttenuationEnd.value !== 'number') {
+            throw new Error('THREE.FBXLoader: Invalid light far attenuation end value');
+          }
+
+          distance = lightAttribute.FarAttenuationEnd.value;
+
+        }
+
+      }
+
+      // TODO: could this be calculated linearly from FarAttenuationStart to FarAttenuationEnd?
+      const decay = 1;
+
+      switch (type) {
+
+        case 0: // Point
+          model = new PointLight(color, intensity, distance, decay);
+
+          break;
+        case 1: // Directional
+          model = new DirectionalLight(color, intensity);
+
+          break;
+        case 2: // Spot
+          {
+            let angle = Math.PI / 3;
+
+            if (lightAttribute.InnerAngle !== undefined) {
+              const innerAngle = lightAttribute.InnerAngle.value;
+
+              if (typeof innerAngle !== 'number') {
+                throw new Error('THREE.FBXLoader: Invalid light inner angle value');
+              }
+              angle = MathUtils.degToRad(innerAngle);
+
+            }
+
+            let penumbra = 0;
+
+            if (lightAttribute.OuterAngle !== undefined) {
+              const outerAngle = lightAttribute.OuterAngle.value;
+
+              if (typeof outerAngle !== 'number') {
+                throw new Error('THREE.FBXLoader: Invalid light outer angle value');
+              }
+
+              // TODO: this is not correct - FBX calculates outer and inner angle in degrees
+              // with OuterAngle > InnerAngle && OuterAngle <= Math.PI
+              // while three.js uses a penumbra between (0, 1) to attenuate the inner angle
+              penumbra = MathUtils.degToRad(outerAngle);
+              penumbra = Math.max(penumbra, 1);
+
+            }
+
+            model = new SpotLight(color, intensity, distance, angle, penumbra, decay);
+          }
+
+          break;
+        default:
+          console.warn('THREE.FBXLoader: Unknown light type ' + lightAttribute.LightType?.value + ', defaulting to a PointLight.');
+          model = new PointLight(color, intensity);
+
+          break;
+
+      }
+
+      if (lightAttribute.CastShadows !== undefined && lightAttribute.CastShadows.value === 1) {
+
+        model.castShadow = true;
+
+      }
+
+    }
+
+    return model;
+
+  }
+
+  createMesh (relationships: FBXConnectionNode, geometryMap: Map<number, BufferGeometry>, materialMap: Map<number, MeshPhongMaterial | MeshStandardMaterial | LineBasicMaterial>) {
+
+    let model;
+    let geometry: BufferGeometry | undefined;
+    let material = null;
+    const materials: (MeshPhongMaterial | MeshStandardMaterial)[] = [];
+
+    // get geometry and materials(s) from connections
+    relationships.children.forEach(function (child) {
+
+      if (geometryMap.has(child.ID)) {
+
+        geometry = geometryMap.get(child.ID);
+
+      }
+
+      if (materialMap.has(child.ID)) {
+
+        materials.push(materialMap.get(child.ID) as MeshStandardMaterial);
+
+      }
+
+    });
+
+    if (materials.length > 1) {
+
+      material = materials;
+
+    } else if (materials.length > 0) {
+
+      material = materials[ 0 ];
+
+    } else {
+
+      material = new MeshPhongMaterial({
+        name: Loader.DEFAULT_MATERIAL_NAME,
+        color: 0xcccccc,
+      });
+      materials.push(material);
+
+    }
+
+    if (!geometry) {
+      throw new Error('THREE.FBXLoader: No geometry found for mesh.');
+    }
+
+    if ('color' in geometry.attributes) {
+
+      materials.forEach(function (material) {
+
+        material.vertexColors = true;
+
+      });
+
+    }
+
+    // Sanitization: If geometry has groups, then it must match the provided material array.
+    // If not, we need to clean up the `group.materialIndex` properties inside the groups and point at a (new) default material.
+    // This isn't well defined; Unity creates default material, while Blender implicitly uses the previous material in the list.
+    if (geometry.groups.length > 0) {
+
+      let needsDefaultMaterial = false;
+
+      for (let i = 0, il = geometry.groups.length; i < il; i ++) {
+
+        const group = geometry.groups[ i ];
+        const materialIndex = group.materialIndex;
+
+        if (!materialIndex) {
+          throw new Error('THREE.FBXLoader: Invalid material index');
+        }
+
+        if (materialIndex < 0 || materialIndex >= materials.length) {
+
+          group.materialIndex = materials.length;
+          needsDefaultMaterial = true;
+
+        }
+
+      }
+
+      if (needsDefaultMaterial) {
+
+        const defaultMaterial = new MeshPhongMaterial();
+
+        materials.push(defaultMaterial);
+
+      }
+
+    }
+
+    if ((geometry as any).FBX_Deformer) {
+
+      model = new SkinnedMesh(geometry, material);
+      model.normalizeSkinWeights();
+
+    } else {
+
+      model = new Mesh(geometry, material);
+
+    }
+
+    return model;
+
+  }
+
+  createCurve (relationships: FBXConnectionNode, geometryMap: Map<number, BufferGeometry>) {
+
+    const geometry = relationships.children.reduce<BufferGeometry | null>((geo, child) => {
+
+      if (geometryMap.has(child.ID)) {
+        geo = geometryMap.get(child.ID) ?? null;
+      }
+      if (!geo) {
+        throw new Error('THREE.FBXLoader: No geometry found for curve.');
+      }
+
+      return geo;
+
+    }, null);
+
+    // FBX does not list materials for Nurbs lines, so we'll just put our own in here.
+    const material = new LineBasicMaterial({
+      name: Loader.DEFAULT_MATERIAL_NAME,
+      color: 0x3300ff,
+      linewidth: 1,
+    });
+
+    if (geometry === null) {
+      throw new Error('THREE.FBXLoader: No geometry found for curve.');
+    }
+
+    return new Line(geometry, material);
+
+  }
+
+  // parse the model node for transform data
+  getTransformData (model: Object3D, modelNode: FBXModelNode) {
+
+    const transformData: UserDataTransform = {};
+
+    if ('InheritType' in modelNode) {transformData.inheritType = parseInt(modelNode.InheritType.value);}
+
+    if ('RotationOrder' in modelNode) {
+      const value = modelNode.RotationOrder.value;
+
+      if (typeof value !== 'number') {
+        throw new Error('THREE.FBXLoader: Invalid rotation order value');
+      }
+      transformData.eulerOrder = getEulerOrder(value) as EulerOrder;
+    } else {
+      transformData.eulerOrder = getEulerOrder(0) as EulerOrder;
+    }
+
+    if ('Lcl_Translation' in modelNode) {
+      transformData.translation = modelNode.Lcl_Translation.value;
+    }
+
+    if ('PreRotation' in modelNode) {transformData.preRotation = modelNode.PreRotation.value;}
+    if ('Lcl_Rotation' in modelNode) {transformData.rotation = modelNode.Lcl_Rotation.value;}
+    if ('PostRotation' in modelNode) {transformData.postRotation = modelNode.PostRotation.value;}
+
+    if ('Lcl_Scaling' in modelNode) {transformData.scale = modelNode.Lcl_Scaling.value;}
+
+    if ('ScalingOffset' in modelNode) {transformData.scalingOffset = modelNode.ScalingOffset.value;}
+    if ('ScalingPivot' in modelNode) {transformData.scalingPivot = modelNode.ScalingPivot.value;}
+
+    if ('RotationOffset' in modelNode) {transformData.rotationOffset = modelNode.RotationOffset.value;}
+    if ('RotationPivot' in modelNode) {transformData.rotationPivot = modelNode.RotationPivot.value;}
+
+    model.userData.transformData = transformData;
+
+  }
+
+  setLookAtProperties (model: Object3D, modelNode: FBXModelNode) {
+    const connections = global.connections;
+    const fbxTree = global.fbxTree;
+
+    if (!connections || !fbxTree) {
+      throw new Error('Global connections or FBX tree is undefined');
+    }
+    if ('LookAtProperty' in modelNode) {
+
+      const children = connections.get((model as any).ID)?.children ?? [];
+
+      children.forEach(function (child) {
+
+        if (child.relationship === 'LookAtProperty') {
+          const modelNode = fbxTree.Objects?.Model;
+
+          if (!modelNode) {
+            throw new Error('Model node is undefined');
+          }
+          const lookAtTarget = modelNode[ child.ID ];
+
+          if ('Lcl_Translation' in lookAtTarget) {
+
+            const pos = lookAtTarget.Lcl_Translation.value;
+
+            // DirectionalLight, SpotLight
+            if ((model as any).target !== undefined) {
+
+              (model as any).target.position.fromArray(pos);
+              global.sceneGraph.add((model as any).target);
+
+            } else { // Cameras and other Object3Ds
+
+              model.lookAt(new Vector3().fromArray(pos));
+
+            }
+
+          }
+
+        }
+
+      });
+
+    }
+
+  }
+
+  bindSkeleton (skeletons: Record<number, FBXSkeleton>, geometryMap: Map<number, BufferGeometry>, modelMap: Map<number, Object3D>) {
+    const fbxTree = global.fbxTree;
+    const connections = global.connections;
+
+    if (!fbxTree || !connections) {
+      throw new Error('Global fbxTree or connections is undefined');
+    }
+
+    const bindMatrices = this.parsePoseNodes();
+
+    for (const ID in skeletons) {
+
+      const skeleton = skeletons[ ID ];
+
+      const parents = connections.get(parseInt(skeleton.ID))?.parents || [];
+
+      parents.forEach(function (parent) {
+
+        if (geometryMap.has(parent.ID)) {
+
+          const geoID = parent.ID;
+          const geoRelationships = connections.get(geoID) || { parents: [] };
+
+          geoRelationships.parents.forEach(function (geoConnParent) {
+
+            if (modelMap.has(geoConnParent.ID)) {
+
+              const model = modelMap.get(geoConnParent.ID) as SkinnedMesh;
+
+              model.bind(new Skeleton(skeleton.bones), bindMatrices[ geoConnParent.ID ]);
+
+            }
+
+          });
+
+        }
+
+      });
+
+    }
+
+  }
+
+  parsePoseNodes () {
+
+    const bindMatrices: Record<string, Matrix4> = {};
+    const fbxTree = global.fbxTree;
+    const connections = global.connections;
+
+    if (!fbxTree || !connections || !fbxTree.Objects) {
+      throw new Error('Global fbxTree or connections is undefined');
+    }
+
+    if ('Pose' in fbxTree.Objects) {
+
+      const BindPoseNode = fbxTree.Objects.Pose;
+
+      for (const nodeID in BindPoseNode) {
+
+        if (BindPoseNode[ nodeID ].attrType === 'BindPose' && BindPoseNode[ nodeID ].NbPoseNodes > 0) {
+
+          const poseNodes = BindPoseNode[ nodeID ].PoseNode;
+
+          if (Array.isArray(poseNodes)) {
+
+            poseNodes.forEach(poseNode => {
+
+              bindMatrices[ (poseNode as FBXMeshNode).Node || 0 ] = new Matrix4().fromArray((poseNode as FBXMeshNode)?.Matrix?.a ?? (((poseNode as unknown as FBXMeshNode[])[0].Matrix)?.a ?? []));
+
+            });
+
+          } else {
+            const node = poseNodes.Node;
+
+            if (!node) {
+              throw new Error('THREE.FBXLoader: No node found for poseNode.');
+            }
+
+            bindMatrices[ node ] = new Matrix4().fromArray(poseNodes?.Matrix?.a ?? []);
+
+          }
+
+        }
+
+      }
+
+    }
+
+    return bindMatrices;
+
+  }
+
+  addGlobalSceneSettings () {
+    const fbxTree = global.fbxTree;
+
+    if (!fbxTree || !fbxTree.GlobalSettings) {
+      throw new Error('Global FBXTree is undefined');
+    }
+    if ('GlobalSettings' in fbxTree) {
+
+      if ('AmbientColor' in fbxTree.GlobalSettings) {
+
+        // Parse ambient color - if it's not set to black (default), create an ambient light
+
+        const ambientColor = fbxTree.GlobalSettings.AmbientColor.value;
+        const r = ambientColor[ 0 ];
+        const g = ambientColor[ 1 ];
+        const b = ambientColor[ 2 ];
+
+        if (r !== 0 || g !== 0 || b !== 0) {
+
+          const color = new Color().setRGB(r, g, b, SRGBColorSpace);
+
+          global.sceneGraph.add(new AmbientLight(color, 1));
+
+        }
+
+      }
+
+      if ('UnitScaleFactor' in fbxTree.GlobalSettings) {
+
+        global.sceneGraph.userData.unitScaleFactor = fbxTree.GlobalSettings.UnitScaleFactor.value;
+
+      }
+
+    }
+
+  }
+
+}

--- a/src/parse/utils.ts
+++ b/src/parse/utils.ts
@@ -1,0 +1,211 @@
+// Returns the three.js intrinsic Euler order corresponding to FBX extrinsic Euler order
+
+import type { EulerTuple, EulerOrder } from 'three';
+import { Euler, Vector3, Matrix4, MathUtils } from 'three';
+import type { FBXTransformData } from '../constants';
+import { FBXEulerOrder } from '../constants';
+
+// ref: http://help.autodesk.com/view/FBX/2017/ENU/?guid=__cpp_ref_class_fbx_euler_html
+export function getEulerOrder (order: FBXEulerOrder): string {
+
+  order = order || 0;
+
+  if (order === FBXEulerOrder.SphericXYZ) {
+
+    console.warn('THREE.FBXLoader: unsupported Euler Order: Spherical XYZ. Animations and rotations may be incorrect.');
+
+    return FBXEulerOrder[ 0 ];
+
+  }
+
+  return FBXEulerOrder[ order ];
+
+}
+
+const tempEuler = new Euler();
+const tempVec = new Vector3();
+const dataArray: any[] = []; // corrected type annotation
+
+// generate transformation from FBX transform data
+// ref: https://help.autodesk.com/view/FBX/2017/ENU/?guid=__files_GUID_10CDD63C_79C1_4F2D_BB28_AD2BE65A02ED_htm
+// ref: http://docs.autodesk.com/FBX/2014/ENU/FBX-SDK-Documentation/index.html?url=cpp_ref/_transformations_2main_8cxx-example.html,topicNumber=cpp_ref__transformations_2main_8cxx_example_htmlfc10a1e1-b18d-4e72-9dc0-70d0f1959f5e
+export function generateTransform (transformData: FBXTransformData) {
+  const lTranslationM = new Matrix4();
+  const lPreRotationM = new Matrix4();
+  const lRotationM = new Matrix4();
+  const lPostRotationM = new Matrix4();
+
+  const lScalingM = new Matrix4();
+  const lScalingPivotM = new Matrix4();
+  const lScalingOffsetM = new Matrix4();
+  const lRotationOffsetM = new Matrix4();
+  const lRotationPivotM = new Matrix4();
+
+  const lParentGX = new Matrix4();
+  const lParentLX = new Matrix4();
+  const lGlobalT = new Matrix4();
+
+  const inheritType = (transformData.inheritType) ? transformData.inheritType : 0;
+
+  if (transformData.translation) {lTranslationM.setPosition(tempVec.fromArray(transformData.translation));}
+
+  // For Maya models using "Joint Orient", Euler order only applies to rotation, not pre/post-rotations
+  const defaultEulerOrder = getEulerOrder(0);
+
+  if (transformData.preRotation) {
+
+    const array = transformData.preRotation.map(MathUtils.degToRad) as EulerTuple;
+    // Maya uses ZYX order for pre-rotation
+
+    (array as string[]).push(defaultEulerOrder);
+    lPreRotationM.makeRotationFromEuler(tempEuler.fromArray(array));
+
+  }
+
+  if (transformData.rotation) {
+
+    const array = transformData.rotation.map(MathUtils.degToRad) as EulerTuple;
+
+    array.push((transformData.eulerOrder || defaultEulerOrder) as EulerOrder);
+    lRotationM.makeRotationFromEuler(tempEuler.fromArray(array));
+
+  }
+
+  if (transformData.postRotation) {
+
+    const array = transformData.postRotation.map(MathUtils.degToRad) as EulerTuple;
+
+    array.push(defaultEulerOrder as EulerOrder);
+    lPostRotationM.makeRotationFromEuler(tempEuler.fromArray(array));
+    lPostRotationM.invert();
+
+  }
+
+  if (transformData.scale) {lScalingM.scale(tempVec.fromArray(transformData.scale));}
+
+  // Pivots and offsets
+  if (transformData.scalingOffset) {lScalingOffsetM.setPosition(tempVec.fromArray(transformData.scalingOffset));}
+  if (transformData.scalingPivot) {lScalingPivotM.setPosition(tempVec.fromArray(transformData.scalingPivot));}
+  if (transformData.rotationOffset) {lRotationOffsetM.setPosition(tempVec.fromArray(transformData.rotationOffset));}
+  if (transformData.rotationPivot) {lRotationPivotM.setPosition(tempVec.fromArray(transformData.rotationPivot));}
+
+  // parent transform
+  if (transformData.parentMatrixWorld) {
+
+    lParentLX.copy(transformData.parentMatrix as Matrix4);
+    lParentGX.copy(transformData.parentMatrixWorld);
+
+  }
+
+  const lLRM = lPreRotationM.clone().multiply(lRotationM).multiply(lPostRotationM);
+  // Global Rotation
+  const lParentGRM = new Matrix4();
+
+  lParentGRM.extractRotation(lParentGX);
+
+  // Global Shear*Scaling
+  const lParentTM = new Matrix4();
+
+  lParentTM.copyPosition(lParentGX);
+
+  const lParentGRSM = lParentTM.clone().invert().multiply(lParentGX);
+  const lParentGSM = lParentGRM.clone().invert().multiply(lParentGRSM);
+  const lLSM = lScalingM;
+
+  const lGlobalRS = new Matrix4();
+
+  if (inheritType === 0) {
+
+    lGlobalRS.copy(lParentGRM).multiply(lLRM).multiply(lParentGSM).multiply(lLSM);
+
+  } else if (inheritType === 1) {
+
+    lGlobalRS.copy(lParentGRM).multiply(lParentGSM).multiply(lLRM).multiply(lLSM);
+
+  } else {
+
+    const lParentLSM = new Matrix4().scale(new Vector3().setFromMatrixScale(lParentLX));
+    const lParentLSM_inv = lParentLSM.clone().invert();
+    const lParentGSM_noLocal = lParentGSM.clone().multiply(lParentLSM_inv);
+
+    lGlobalRS.copy(lParentGRM).multiply(lLRM).multiply(lParentGSM_noLocal).multiply(lLSM);
+
+  }
+
+  const lRotationPivotM_inv = lRotationPivotM.clone().invert();
+  const lScalingPivotM_inv = lScalingPivotM.clone().invert();
+  // Calculate the local transform matrix
+  let lTransform = lTranslationM.clone().multiply(lRotationOffsetM).multiply(lRotationPivotM).multiply(lPreRotationM).multiply(lRotationM).multiply(lPostRotationM).multiply(lRotationPivotM_inv).multiply(lScalingOffsetM).multiply(lScalingPivotM).multiply(lScalingM).multiply(lScalingPivotM_inv);
+
+  const lLocalTWithAllPivotAndOffsetInfo = new Matrix4().copyPosition(lTransform);
+
+  const lGlobalTranslation = lParentGX.clone().multiply(lLocalTWithAllPivotAndOffsetInfo);
+
+  lGlobalT.copyPosition(lGlobalTranslation);
+
+  lTransform = lGlobalT.clone().multiply(lGlobalRS);
+
+  // from global to local
+  lTransform.premultiply(lParentGX.invert());
+
+  return lTransform;
+
+}
+
+function slice (a: number[], b: number[], from: number, to: number): number[] {
+
+  for (let i = from, j = 0; i < to; i ++, j ++) {
+
+    a[ j ] = b[ i ];
+
+  }
+
+  return a;
+
+}
+
+// extracts the data from the correct position in the FBX array based on indexing type
+export function getData (polygonVertexIndex: number, polygonIndex: number, vertexIndex: number, infoObject: { mappingType: string, indices: number[], referenceType: string, dataSize: number, buffer: number[] }): number[] {
+
+  let index = 0;
+
+  switch (infoObject.mappingType) {
+
+    case 'ByPolygonVertex' :
+      index = polygonVertexIndex;
+
+      break;
+    case 'ByPolygon' :
+      index = polygonIndex;
+
+      break;
+    case 'ByVertice' :
+      index = vertexIndex;
+
+      break;
+    case 'AllSame' :
+      index = infoObject.indices[ 0 ];
+
+      break;
+    default :
+      console.warn('THREE.FBXLoader: unknown attribute mapping type ' + infoObject.mappingType);
+
+  }
+
+  if (infoObject.referenceType === 'IndexToDirect') {
+    index = infoObject.indices[ index ];
+  }
+
+  const from = index * infoObject.dataSize;
+  const to = from + infoObject.dataSize;
+
+  return slice(dataArray, infoObject.buffer, from, to);
+
+}
+
+// Converts FBX ticks into real time seconds.
+export function convertFBXTimeToSeconds (time: number): number {
+
+  return time / 46186158000;
+
+}

--- a/src/type/fbx-tree.ts
+++ b/src/type/fbx-tree.ts
@@ -1,9 +1,0 @@
-import type { Node } from '@gltf-transform/core';
-
-export interface ModelInfo {
-  type: string,
-  parent: number,
-  modelIndex: number,
-  ID: number,
-  node: Node,
-}


### PR DESCRIPTION
- Implemented `getEulerOrder` to map FBX extrinsic Euler orders to three.js intrinsic orders.
- Added `generateTransform` to create transformation matrices from FBX transform data, handling translation, rotation, scaling, and pivot offsets.
- Introduced `getData` to extract vertex data based on mapping types from FBX arrays.
- Added `convertFBXTimeToSeconds` to convert FBX ticks into real-time seconds.
- Removed unused `fbx-tree.ts` file.